### PR TITLE
feat: Add emojis to problem groups

### DIFF
--- a/packages/backend/src/problem/free/3sum/groups.ts
+++ b/packages/backend/src/problem/free/3sum/groups.ts
@@ -5,10 +5,12 @@ export const groups: GroupMetadata[] = [
     name: "tripletInfo",
     label: "Triplet Info",
     description: "Details about the current triplet being examined and its sum.",
+    emoji: "🔢",
   },
   {
     name: "pointers",
     label: "Loop Pointers",
     description: "Indices used to iterate through the sorted array.",
+    emoji: "📍",
   },
 ];

--- a/packages/backend/src/problem/free/bestTimeToBuyAndSellStocks/groups.ts
+++ b/packages/backend/src/problem/free/bestTimeToBuyAndSellStocks/groups.ts
@@ -4,16 +4,19 @@ export const groups = [
 	  label: "Potential Profit Calculation",
 	  description:
 		"The potential profit from buying at the minimum price and selling at the current price.",
+    emoji: "💰",
 	},
 	{
 	  name: "smaller",
 	  label: "Profit Comparison with Previous Minimum",
 	  description:
 		"The potential profit from buying at the minimum price and selling at the current price minus the minimum price found so far.",
+    emoji: "🤔",
 	},
 	{
 	  name: "loop",
 	  label: "Current Day in Price Analysis Loop",
 	  description: "The current day being considered (prices[i]).",
+    emoji: "🗓️",
 	},
   ]

--- a/packages/backend/src/problem/free/climbingStairs/groups.ts
+++ b/packages/backend/src/problem/free/climbingStairs/groups.ts
@@ -10,10 +10,12 @@ export const groups: VariableGroup[] = [
     name: "input",
     label: "Input",
     description: "Input value for the problem.",
+    emoji: "📥",
   },
   {
     name: "computation",
     label: "Computation",
     description: "Variables used during computation.",
+    emoji: "⚙️",
   },
 ];

--- a/packages/backend/src/problem/free/coinChange/groups.ts
+++ b/packages/backend/src/problem/free/coinChange/groups.ts
@@ -10,20 +10,24 @@ export const groups: VariableGroup[] = [
     name: "input",
     label: "Input",
     description: "Input parameters for the problem.",
+    emoji: "📥",
   },
   {
     name: "dp_table",
     label: "DP Table",
     description: "Dynamic programming table storing intermediate results.",
+    emoji: "📊",
   },
   {
     name: "loops",
     label: "Loops",
     description: "Variables related to the main loops.",
+    emoji: "🔁",
   },
   {
     name: "result",
     label: "Result",
     description: "Final result of the computation.",
+    emoji: "🏁",
   },
 ];

--- a/packages/backend/src/problem/free/countingBits/groups.ts
+++ b/packages/backend/src/problem/free/countingBits/groups.ts
@@ -5,15 +5,18 @@ export const groups: VariableGroup[] = [
     name: "loop",
     label: "Outer Loop Iteration",
     description: "Tracks the current number 'i' being processed from 0 to n.",
+    emoji: "🔁",
   },
   {
     name: "count",
     label: "Bit Counting",
     description: "Tracks the number of set bits ('1's) for the current number.",
+    emoji: "🧮",
   },
   {
       name: "binaryRepresentation",
       label: "Binary Representation",
       description: "Shows the binary representation of the number being processed.",
+      emoji: "💻",
   }
 ];

--- a/packages/backend/src/problem/free/course-schedule/groups.ts
+++ b/packages/backend/src/problem/free/course-schedule/groups.ts
@@ -6,26 +6,31 @@ export const courseScheduleGroups: GroupDefinition[] = [
     id: "input",
     title: "Input",
     variables: ["numCourses", "prerequisites"],
+    emoji: "📥",
   },
   {
     id: "state",
     title: "Algorithm State",
     variables: ["graph", "inDegree", "queue", "count"],
+    emoji: "📊",
   },
   {
     id: "processing",
     title: "Current Processing",
     variables: ["current", "neighbor", "prev"], // Added 'prev' based on logStep usage
+    emoji: "⚙️",
   },
   {
     id: "result",
     title: "Result",
     variables: ["allCoursesTaken"],
+    emoji: "🏁",
   },
   // Add other potential simple value variables used in logging
   {
       id: "tempValues",
       title: "Temporary Values",
-      variables: ["course", "prereq", "deg"]
+      variables: ["course", "prereq", "deg"],
+      emoji: "🧪",
   }
 ];

--- a/packages/backend/src/problem/free/editDistance/groups.ts
+++ b/packages/backend/src/problem/free/editDistance/groups.ts
@@ -1,8 +1,8 @@
 import { Group } from "algo-lens-core";
 
 export const groups: Group[] = [
-  { title: "Inputs", variables: ["s1", "s2"] },
-  { title: "DP Table", variables: ["dp"] },
-  { title: "Loop Variables", variables: ["i", "j", "op"] },
-  { title: "Result", variables: ["result", "s1Length", "s2Length"] },
+  { title: "Inputs", variables: ["s1", "s2"], emoji: "📥" },
+  { title: "DP Table", variables: ["dp"], emoji: "📊" },
+  { title: "Loop Variables", variables: ["i", "j", "op"], emoji: "🔁" },
+  { title: "Result", variables: ["result", "s1Length", "s2Length"], emoji: "🏁" },
 ];

--- a/packages/backend/src/problem/free/houseRobber/groups.ts
+++ b/packages/backend/src/problem/free/houseRobber/groups.ts
@@ -1,7 +1,7 @@
 import { VariableGroup } from "algo-lens-core";
 
 export const groups: VariableGroup[] = [
-  { name: "dpCalculation", title: "DP Calculation" },
-  { name: "loopInfo", title: "Loop Info" },
-  { name: "result", title: "Result" }, // Added for final result
+  { name: "dpCalculation", title: "DP Calculation", emoji: "💰" },
+  { name: "loopInfo", title: "Loop Info", emoji: "🔁" },
+  { name: "result", title: "Result", emoji: "🏁" }, // Added for final result
 ];

--- a/packages/backend/src/problem/free/insert-interval/groups.ts
+++ b/packages/backend/src/problem/free/insert-interval/groups.ts
@@ -10,15 +10,18 @@ export const groups: VariableGroup[] = [
     name: "input",
     label: "Input",
     description: "Input intervals and the new interval to insert.",
+    emoji: "📥",
   },
   {
     name: "result_array",
     label: "Result Array",
     description: "The array being built with merged intervals.",
+    emoji: "📋",
   },
   {
     name: "loop_merging",
     label: "Loop/Merging",
     description: "Variables used during iteration and merging.",
+    emoji: "⚙️",
   },
 ];

--- a/packages/backend/src/problem/free/maximum-subarray/groups.ts
+++ b/packages/backend/src/problem/free/maximum-subarray/groups.ts
@@ -10,15 +10,18 @@ export const groups: VariableGroup[] = [
     name: "input",
     label: "Input",
     description: "Input array for the problem.",
+    emoji: "📥",
   },
   {
     name: "kadane_vars", // Changed from kandane for consistency
     label: "Kadane's Variables",
     description: "Variables used in Kadane's algorithm.",
+    emoji: "💡",
   },
   {
     name: "loop",
     label: "Loop",
     description: "Variables related to the iteration.",
+    emoji: "🔁",
   },
 ];

--- a/packages/backend/src/problem/free/missingNumber/groups.ts
+++ b/packages/backend/src/problem/free/missingNumber/groups.ts
@@ -5,10 +5,12 @@ export const groups: ValueGroupMetadata[] = [
     name: "sum",
     label: "Sum Calculation",
     description: "Variables related to calculating the expected and actual sums.",
+    emoji: "➕",
   },
   {
     name: "loop",
     label: "Loop Variables",
     description: "Variables used within the main loop.",
+    emoji: "🔁",
   },
 ];


### PR DESCRIPTION
Adds an `emoji` property to the group metadata objects in various `groups.ts` files within the backend problems directory (`packages/backend/src/problem/free/`).

This enhances the visual representation of problem groups in the UI. Emojis were chosen based on the context of each group (e.g., name, label, description). Files that were empty or did not export a `groups` array were skipped.