### PR TITLE
Refactor: Standardize problem export variable name to 'problem'

### DIFF
--- a/packages/backend/src/problem/free/3sum/problem.ts
+++ b/packages/backend/src/problem/free/3sum/problem.ts
@@ -6,7 +6,7 @@ import { code } from "./code";
 import { ThreeSumInput } from "./types";
 import { threeSumTestCases } from "./testcase";
 
-export const threeSumProblem: Problem<ThreeSumInput, ProblemState> = {
+export const problem: Problem<ThreeSumInput, ProblemState> = {
   title: "Three Sum",
   code: code,
   getInput: () => ({

--- a/packages/backend/src/problem/free/bestTimeToBuyAndSellStocks/problem.ts
+++ b/packages/backend/src/problem/free/bestTimeToBuyAndSellStocks/problem.ts
@@ -10,7 +10,7 @@ import { MaxProfitInput } from "./types";
 const title = "Best Time to Buy and Sell Stock";
 const getInput = () => ({ prices: [7, 1, 5, 3, 6, 4] });
 
-export const maxProfitProblem: Problem<MaxProfitInput, ProblemState> = {
+export const problem: Problem<MaxProfitInput, ProblemState> = {
   title: title,
   code: code,
   getInput: getInput,

--- a/packages/backend/src/problem/free/climbingStairs/problem.ts
+++ b/packages/backend/src/problem/free/climbingStairs/problem.ts
@@ -8,7 +8,7 @@ import { ClimbingStairsInput } from "./types";
 const title = "Climbing Stairs";
 const getInput = () => ({ n: 8 });
 
-export const climbStairsProblem: Problem<ClimbingStairsInput, ProblemState> = {
+export const problem: Problem<ClimbingStairsInput, ProblemState> = {
   title: title,
   code: code,
   getInput: getInput,

--- a/packages/backend/src/problem/free/coinChange/problem.ts
+++ b/packages/backend/src/problem/free/coinChange/problem.ts
@@ -8,7 +8,7 @@ import { CoinChangeInput } from "./types";
 const title = "Coin Change";
 const getInput = () => ({ coins: [1, 2, 5], target: 11 });
 
-export const coinChangeProblem: Problem<CoinChangeInput, ProblemState> = {
+export const problem: Problem<CoinChangeInput, ProblemState> = {
   title: title,
   code: code,
   getInput: getInput,

--- a/packages/backend/src/problem/free/container-with-most-water/problem.ts
+++ b/packages/backend/src/problem/free/container-with-most-water/problem.ts
@@ -8,7 +8,7 @@ const getInput = () => ({
   height: [1, 8, 6, 2, 5, 4, 8, 3, 7],
 });
 
-export const maxAreaProblem: Problem<ContainerInput, ProblemState> = {
+export const problem: Problem<ContainerInput, ProblemState> = {
   title,
   code,
   getInput,

--- a/packages/backend/src/problem/free/containsDuplicate/problem.ts
+++ b/packages/backend/src/problem/free/containsDuplicate/problem.ts
@@ -60,7 +60,7 @@ const getInput = () => ({
 });
 
 // Export the complete problem setup including the input function, the computational function, and other metadata
-export const containsDuplicateProblem: Problem<
+export const problem: Problem<
   ContainsDuplicateInput,
   ProblemState
 > = {

--- a/packages/backend/src/problem/free/countingBits/problem.ts
+++ b/packages/backend/src/problem/free/countingBits/problem.ts
@@ -10,7 +10,7 @@ const getInput = () => ({
   n: 15, // Using the same example input as the original file
 });
 
-export const countBitsProblem: Problem<CountBitsInput, ProblemState> = {
+export const problem: Problem<CountBitsInput, ProblemState> = {
   title: title,
   code: code,
   getInput: getInput,

--- a/packages/backend/src/problem/free/course-schedule/problem.ts
+++ b/packages/backend/src/problem/free/course-schedule/problem.ts
@@ -25,7 +25,7 @@ const getInput = (): CourseScheduleInput => ({
 });
 
 // Define the problem structure
-export const courseScheduleProblem: Problem<CourseScheduleInput, ProblemState> =
+export const problem: Problem<CourseScheduleInput, ProblemState> =
   {
     title: title,
     code: code, // Use the imported code string

--- a/packages/backend/src/problem/free/editDistance/problem.ts
+++ b/packages/backend/src/problem/free/editDistance/problem.ts
@@ -8,7 +8,7 @@ import { groups } from "./groups";
 const title = "Edit Distance";
 const getInput = (): EditDistanceInput => ({ s1: "kitten", s2: "sitting" });
 
-export const editDistanceProblem: Problem<EditDistanceInput, ProblemState> = {
+export const problem: Problem<EditDistanceInput, ProblemState> = {
   title,
   id: "edit-distance",
   tags: ["dynamic programming", "string"],

--- a/packages/backend/src/problem/free/houseRobber/problem.ts
+++ b/packages/backend/src/problem/free/houseRobber/problem.ts
@@ -8,7 +8,7 @@ import { variableMetadata } from "./variables"; // Import variableMetadata
 const title = "House Robber";
 const getInput = () => ({ nums: [2, 7, 9, 3, 1] }); // Ensure getInput is defined
 
-export const houseRobberProblem: Problem<HouseRobberInput, ProblemState> = {
+export const problem: Problem<HouseRobberInput, ProblemState> = {
   title: title,
   code: code, // Use imported code
   getInput: getInput,

--- a/packages/backend/src/problem/free/insert-interval/problem.ts
+++ b/packages/backend/src/problem/free/insert-interval/problem.ts
@@ -11,7 +11,7 @@ const getInput = () => ({
   newInterval: [2, 5] as Interval, // Add type assertion for clarity
 });
 
-export const insertIntervalProblem: Problem<InsertIntervalInput, ProblemState> = {
+export const problem: Problem<InsertIntervalInput, ProblemState> = {
   title: title,
   code: code,
   getInput: getInput,

--- a/packages/backend/src/problem/free/longestIncreasingSubsequence/problem.ts
+++ b/packages/backend/src/problem/free/longestIncreasingSubsequence/problem.ts
@@ -6,7 +6,7 @@ import { LISInput } from "./types"; // Import input type from types.ts
 const title = "Longest Increasing Subsequence";
 const getInput = () => ({ nums: [10, 9, 2, 5, 3, 7, 101, 18] });
 
-export const longestIncreasingSubsequenceProblem: Problem<LISInput, ProblemState> = {
+export const problem: Problem<LISInput, ProblemState> = {
     title: title,
     code: code,
     getInput: getInput,

--- a/packages/backend/src/problem/free/maximum-subarray/problem.ts
+++ b/packages/backend/src/problem/free/maximum-subarray/problem.ts
@@ -12,7 +12,7 @@ const getInput = () => ({
   nums: [-2, 2, 1, -9, 4, -7, 2, 1, 1, 5, -5, 4], // Output: 10
 });
 
-export const maximumSubarrayProblem: Problem<MaximumSubarrayInput, ProblemState> = {
+export const problem: Problem<MaximumSubarrayInput, ProblemState> = {
   title: title,
   code: code,
   getInput: getInput,

--- a/packages/backend/src/problem/free/merge-intervals/problem.ts
+++ b/packages/backend/src/problem/free/merge-intervals/problem.ts
@@ -18,7 +18,7 @@ const getInput = () => ({
   ],
 });
 
-export const mergeIntervalsProblem: Problem<
+export const problem: Problem<
   MergeIntervalsInput,
   ProblemState
 > = {

--- a/packages/backend/src/problem/free/minimumPathSum/problem.ts
+++ b/packages/backend/src/problem/free/minimumPathSum/problem.ts
@@ -14,7 +14,7 @@ const getInput = () => ({
 
 // Note: The original file used MinPathSumState, but ProblemState is the standard.
 // If specific state aspects were needed, they'd be handled within generateSteps.
-export const minPathSumProblem: Problem<MinPathSumInput, ProblemState> = {
+export const problem: Problem<MinPathSumInput, ProblemState> = {
   title: title,
   code: code,
   getInput: getInput,

--- a/packages/backend/src/problem/free/missingNumber/problem.ts
+++ b/packages/backend/src/problem/free/missingNumber/problem.ts
@@ -14,7 +14,7 @@ const getInput = () => ({
 });
 
 // Export the complete problem setup
-export const missingNumberProblem: Problem<MissingNumberInput> = {
+export const problem: Problem<MissingNumberInput> = {
   title,
   id: "missing-number",
   tags: ["math", "array"],

--- a/packages/backend/src/problem/free/non-overlapping-intervals/problem.ts
+++ b/packages/backend/src/problem/free/non-overlapping-intervals/problem.ts
@@ -17,7 +17,7 @@ const getInput = () => ({
   ],
 });
 
-export const eraseOverlapIntervalsProblem: Problem<
+export const problem: Problem<
   EraseOverlapIntervalsInput,
   ProblemState
 > = {

--- a/packages/backend/src/problem/free/number-of-1-bits/problem.ts
+++ b/packages/backend/src/problem/free/number-of-1-bits/problem.ts
@@ -6,7 +6,7 @@ import { HammingWeightInput } from "./types"; // Import input type from types.ts
 const title = "Hamming Weight";
 const getInput = () => ({ n: 9 });
 
-export const hammingWeightProblem: Problem<HammingWeightInput, ProblemState> = {
+export const problem: Problem<HammingWeightInput, ProblemState> = {
   title,
   code,
   getInput,

--- a/packages/backend/src/problem/free/number-of-islands/problem.ts
+++ b/packages/backend/src/problem/free/number-of-islands/problem.ts
@@ -15,7 +15,7 @@ const getInput = () => ({
 });
 
 // Export the complete problem setup including the input function, the computational function, and other metadata
-export const numIslandsProblem: Problem<NumIslandsInput, ProblemState> = {
+export const problem: Problem<NumIslandsInput, ProblemState> = {
   title,
   code,
   getInput,

--- a/packages/backend/src/problem/free/pacific-atlantic-water-flow/problem.ts
+++ b/packages/backend/src/problem/free/pacific-atlantic-water-flow/problem.ts
@@ -17,7 +17,7 @@ const getInput = () => ({
 
 // Export the complete problem setup including the input function, the computational function, and other metadata
 // Note: Original problem didn't have tags, so omitting them here.
-export const pacificAtlanticWaterFlowProblem: Problem<PacificAtlanticInput, ProblemState> = {
+export const problem: Problem<PacificAtlanticInput, ProblemState> = {
   title,
   code,
   getInput,

--- a/packages/backend/src/problem/free/product-of-array-except-self.ts
+++ b/packages/backend/src/problem/free/product-of-array-except-self.ts
@@ -109,7 +109,7 @@ const getInput = () => ({
 });
 
 // Export the complete problem setup including the input function, the computational function, and other metadata
-export const productExceptSelfProblem: Problem<
+export const problem: Problem<
   ProductExceptSelfInput,
   ProblemState
 > = {

--- a/packages/backend/src/problem/free/reverse-linked-list.ts
+++ b/packages/backend/src/problem/free/reverse-linked-list.ts
@@ -105,7 +105,7 @@ const getInput = () => {
   return { head:head };
 };
 
-export const reverseListProblem: Problem<ReverseListInput, ProblemState> = {
+export const problem: Problem<ReverseListInput, ProblemState> = {
   title,
   code,
   getInput,

--- a/packages/backend/src/problem/free/sameTree.ts
+++ b/packages/backend/src/problem/free/sameTree.ts
@@ -121,7 +121,7 @@ const getInput = () => {
   return result;
 };
 
-export const sameTreeProblem: Problem<SameTreeInput, ProblemState> = {
+export const problem: Problem<SameTreeInput, ProblemState> = {
   title,
   code,
   getInput,

--- a/packages/backend/src/problem/free/search-in-rotated-sorted-array.ts
+++ b/packages/backend/src/problem/free/search-in-rotated-sorted-array.ts
@@ -133,7 +133,7 @@ const getInput = () => ({
 });
 
 // Export the complete problem setup including the input function, the computational function, and other metadata
-export const searchProblem: Problem<SearchInput, ProblemState> = {
+export const problem: Problem<SearchInput, ProblemState> = {
   title,
   code,
   getInput,

--- a/packages/backend/src/problem/free/set-matrix-zeros.ts
+++ b/packages/backend/src/problem/free/set-matrix-zeros.ts
@@ -225,7 +225,7 @@ const getInput = () => ({
 });
 
 // Export the complete problem setup including the input function, the computational function, and other metadata
-export const setMatrixZeroesProblem: Problem<
+export const problem: Problem<
   SetMatrixZeroesInput,
   ProblemState
 > = {

--- a/packages/backend/src/problem/free/sum-of-two-integers.ts
+++ b/packages/backend/src/problem/free/sum-of-two-integers.ts
@@ -110,7 +110,7 @@ const code = `function sumOfTwoIntegers(a: number, b: number): number {
 }`;
 
 // Export the complete problem setup including the input function, the computational function, and other metadata
-export const sumOfTwoIntegersProblem: Problem<SumOfTwoIntegersInput, number> = {
+export const problem: Problem<SumOfTwoIntegersInput, number> = {
   title: "Sum of Two Integers",
   code,
   getInput: () => ({ a: 3, b: 5 }),

--- a/packages/backend/src/problem/free/two-sum.ts
+++ b/packages/backend/src/problem/free/two-sum.ts
@@ -55,7 +55,7 @@ export function twoSum(p: TwoSumInput): ProblemState[] {
   return steps;
 }
 
-export const twoSumProblem: Problem<TwoSumInput, ProblemState> = {
+export const problem: Problem<TwoSumInput, ProblemState> = {
   title: "Two Sum",
   code: `function twoSum(nums: number[], target: number): number[] {
     const seen = new Map();

--- a/packages/backend/src/problem/free/uniquePaths.ts
+++ b/packages/backend/src/problem/free/uniquePaths.ts
@@ -83,7 +83,7 @@ const code = `function uniquePaths(m: number, n: number): number {
 const title = "Unique Paths";
 const getInput = () => ({ m: 3, n: 7 });
 
-export const uniquePathsProblem: Problem<UniquePathsInput, UniquePathsState> = {
+export const problem: Problem<UniquePathsInput, UniquePathsState> = {
   title: title,
   code: code,
   getInput: getInput,

--- a/packages/backend/src/problem/free/wordBreak.ts
+++ b/packages/backend/src/problem/free/wordBreak.ts
@@ -88,7 +88,7 @@ const getInput = () => ({
   wordDict: ["cats", "dog", "sand", "and", "cat"],
 });
 
-export const wordBreakProblem: Problem<WordBreakInput, ProblemState> = {
+export const problem: Problem<WordBreakInput, ProblemState> = {
   title: title,
   code: code,
   getInput: getInput,


### PR DESCRIPTION
Renamed the exported constant in all problem definition files within `packages/backend/src/problem/free` from `<problemName>Problem` to a generic `problem`.

This standardizes the export across all problems, simplifying how they might be imported or processed elsewhere.