### PR TITLE
Refactor: Standardize problem definitions and add test cases.

### DIFF
--- a/packages/backend/src/problem/free/bestTimeToBuyAndSellStocks/problem.ts
+++ b/packages/backend/src/problem/free/bestTimeToBuyAndSellStocks/problem.ts
@@ -4,17 +4,17 @@ import { generateSteps } from "./steps";
 import { groups } from "./groups";
 import { code } from "./code";
 import { MaxProfitInput } from "./types";
-
+import { maxProfitTestCases } from './testcase';
 
 
 const title = "Best Time to Buy and Sell Stock";
-const getInput = () => ({ prices: [7, 1, 5, 3, 6, 4] });
 
 export const problem: Problem<MaxProfitInput, ProblemState> = {
   title: title,
   code: code,
   func: generateSteps,
   id: "best-time-to-buy-and-sell-stock",
+  testCases: maxProfitTestCases,
   tags: ["dynamic programming"],
   metadata: {
     variables: variableMetadata,

--- a/packages/backend/src/problem/free/bestTimeToBuyAndSellStocks/testcase.ts
+++ b/packages/backend/src/problem/free/bestTimeToBuyAndSellStocks/testcase.ts
@@ -1,0 +1,11 @@
+import { TestCase } from '../../problem.types';
+import { MaxProfitInput } from './types'; // Assuming MaxProfitInput is defined in types.ts
+
+export const maxProfitTestCases: TestCase<MaxProfitInput, number>[] = [
+  { input: { prices: [7, 1, 5, 3, 6, 4] }, expected: 5 },
+  { input: { prices: [7, 6, 4, 3, 1] }, expected: 0 },
+  { input: { prices: [1, 2, 3, 4, 5] }, expected: 4 },
+  { input: { prices: [2, 1, 2, 0, 1, 2] }, expected: 2 },
+  { input: { prices: [1] }, expected: 0 },
+  { input: { prices: [] }, expected: 0 },
+];

--- a/packages/backend/src/problem/free/climbingStairs/problem.ts
+++ b/packages/backend/src/problem/free/climbingStairs/problem.ts
@@ -4,18 +4,17 @@ import { generateSteps } from "./steps";
 import { groups } from "./groups";
 import { code } from "./code";
 import { ClimbingStairsInput } from "./types";
+import { climbingStairsTestCases } from './testcase';
 
 const title = "Climbing Stairs";
-const getInput = () => ({ n: 8 });
 
 export const problem: Problem<ClimbingStairsInput, ProblemState> = {
   title: title,
   code: code,
-  getInput: getInput,
   func: generateSteps, // Use generateSteps from steps.ts
+  testCases: climbingStairsTestCases,
   id: "climbing-stairs",
   tags: ["dynamic programming"],
-  tested: true,
   metadata: {
     variables: variableMetadata,
     groups: groups,

--- a/packages/backend/src/problem/free/climbingStairs/testcase.ts
+++ b/packages/backend/src/problem/free/climbingStairs/testcase.ts
@@ -1,0 +1,10 @@
+import { TestCase } from '../../problem.types';
+import { ClimbingStairsInput } from './types'; // Assuming ClimbingStairsInput is defined in types.ts
+
+export const climbingStairsTestCases: TestCase<ClimbingStairsInput, number>[] = [
+  { input: { n: 1 }, expected: 1 },
+  { input: { n: 2 }, expected: 2 },
+  { input: { n: 3 }, expected: 3 },
+  { input: { n: 5 }, expected: 8 },
+  { input: { n: 8 }, expected: 34 },
+];

--- a/packages/backend/src/problem/free/coinChange/problem.ts
+++ b/packages/backend/src/problem/free/coinChange/problem.ts
@@ -4,18 +4,17 @@ import { generateSteps } from "./steps";
 import { groups } from "./groups";
 import { code } from "./code";
 import { CoinChangeInput } from "./types";
+import { coinChangeTestCases } from './testcase';
 
 const title = "Coin Change";
-const getInput = () => ({ coins: [1, 2, 5], target: 11 });
 
 export const problem: Problem<CoinChangeInput, ProblemState> = {
   title: title,
   code: code,
-  getInput: getInput,
   func: generateSteps, // Use generateSteps from steps.ts
+  testCases: coinChangeTestCases,
   id: "coin-change",
   tags: ["dynamic programming"],
-  tested: true,
   metadata: {
     variables: variableMetadata,
     groups: groups,

--- a/packages/backend/src/problem/free/coinChange/testcase.ts
+++ b/packages/backend/src/problem/free/coinChange/testcase.ts
@@ -1,0 +1,11 @@
+import { TestCase } from '../../problem.types';
+import { CoinChangeInput } from './types'; // Assuming CoinChangeInput is defined in types.ts
+
+export const coinChangeTestCases: TestCase<CoinChangeInput, number>[] = [
+  { input: { coins: [1, 2, 5], target: 11 }, expected: 3 },
+  { input: { coins: [2], target: 3 }, expected: -1 },
+  { input: { coins: [1], target: 0 }, expected: 0 },
+  { input: { coins: [1], target: 1 }, expected: 1 },
+  { input: { coins: [1], target: 2 }, expected: 2 },
+  { input: { coins: [186, 419, 83, 408], target: 6249 }, expected: 20 },
+];


### PR DESCRIPTION
Removes `getInput`, `hide`, and `tested` fields from problem definitions. Adds a `testCases` field to each problem, linking to test cases defined in a corresponding `testcase.ts` file (for directory-based problems) or within the file itself (for single-file problems).

This commit applies the changes to:
- container-with-most-water
- containsDuplicate
- countingBits
- course-schedule
- editDistance
- houseRobber
- insert-interval
- bestTimeToBuyAndSellStocks
- climbingStairs
- coinChange

Further work is needed to apply these changes to the remaining problems in packages/backend/src/problem/free/.