### PR TITLE
Fix: Correct import paths for core/utils in problem steps

### DIFF
--- a/packages/backend/src/problem/free/container-with-most-water/steps.ts
+++ b/packages/backend/src/problem/free/container-with-most-water/steps.ts
@@ -4,7 +4,7 @@ import {
   asArray,
   // Removed unused imports
   asValueGroup,
-} from "../core/utils";
+} from "../../core/utils";
 import { ContainerInput } from "./types"; // Import from ./types
 
 // Export ContainerInput as per instruction (even though it's imported)

--- a/packages/backend/src/problem/free/course-schedule/steps.ts
+++ b/packages/backend/src/problem/free/course-schedule/steps.ts
@@ -6,7 +6,7 @@ import {
   asValueGroup,
   asBooleanGroup,
   from2dArrayToMap,
-} from "../../../core/utils"; // Adjusted import path
+} from "../../core/utils"; // Adjusted import path
 import { LogExtraInfo } from "./types"; // Import from types.ts
 
 // This function will be called by the main algorithm to log state

--- a/packages/backend/src/problem/free/longestIncreasingSubsequence/steps.ts
+++ b/packages/backend/src/problem/free/longestIncreasingSubsequence/steps.ts
@@ -1,5 +1,5 @@
 import { ProblemState } from "algo-lens-core"; // Removed Problem, Variable
-import { asArray, asSimpleValue, asValueGroup } from "../core/utils";
+import { asArray, asSimpleValue, asValueGroup } from "../../core/utils";
 import { LISInput } from "./types"; // Import LISInput
 
 export function generateSteps(p: LISInput): ProblemState[] { // Renamed and Exported

--- a/packages/backend/src/problem/free/merge-intervals/steps.ts
+++ b/packages/backend/src/problem/free/merge-intervals/steps.ts
@@ -3,7 +3,7 @@ import {
   // Removed unused imports
   asIntervals,
   getIntervalBounds,
-} from "../core/utils";
+} from "../../core/utils";
 import { MergeIntervalsInput } from "./types"; // Import MergeIntervalsInput
 
 export function generateSteps(p: MergeIntervalsInput): ProblemState[] { // Renamed and Exported

--- a/packages/backend/src/problem/free/minimumPathSum/steps.ts
+++ b/packages/backend/src/problem/free/minimumPathSum/steps.ts
@@ -1,5 +1,5 @@
 import { ProblemState } from "algo-lens-core"; // Removed Problem
-import { as2dArray, asArray, asSimpleValue } from "../core/utils";
+import { as2dArray, asArray, asSimpleValue } from "../../core/utils";
 import { MinPathSumInput } from "./types"; // Import MinPathSumInput
 
 export function generateSteps(p: MinPathSumInput): ProblemState[] { // Renamed and Exported

--- a/packages/backend/src/problem/free/non-overlapping-intervals/steps.ts
+++ b/packages/backend/src/problem/free/non-overlapping-intervals/steps.ts
@@ -4,7 +4,7 @@ import {
   asValueGroup,
   asIntervals,
   getIntervalBounds,
-} from "../core/utils";
+} from "../../core/utils";
 import { EraseOverlapIntervalsInput } from "./types"; // Import EraseOverlapIntervalsInput
 
 export function generateSteps( // Renamed and Exported

--- a/packages/backend/src/problem/free/number-of-1-bits/steps.ts
+++ b/packages/backend/src/problem/free/number-of-1-bits/steps.ts
@@ -1,5 +1,5 @@
 import { ProblemState } from "algo-lens-core"; // Removed Problem
-import { asBinary, asValueGroup } from "../core/utils";
+import { asBinary, asValueGroup } from "../../core/utils";
 import { HammingWeightInput } from "./types"; // Import HammingWeightInput
 
 export function generateSteps(p: HammingWeightInput): ProblemState[] { // Renamed and Exported

--- a/packages/backend/src/problem/free/number-of-islands/steps.ts
+++ b/packages/backend/src/problem/free/number-of-islands/steps.ts
@@ -1,7 +1,7 @@
 // Imports specific utility functions and type definitions from the relative paths
 import { cloneDeep } from "lodash";
 import { ProblemState, Variable } from "algo-lens-core"; // Removed Problem
-import { as2dArray, asValueGroup, deepClone2DArray } from "../core/utils";
+import { as2dArray, asValueGroup, deepClone2DArray } from "../../core/utils";
 import { NumIslandsInput } from "./types"; // Import NumIslandsInput
 
 // Removed duplicate NumIslandsInput interface definition

--- a/packages/backend/src/problem/free/pacific-atlantic-water-flow/steps.ts
+++ b/packages/backend/src/problem/free/pacific-atlantic-water-flow/steps.ts
@@ -5,7 +5,7 @@ import {
   asArray,
   as2dArray,
   // Removed unused imports asSimpleValue, asStringArray, asValueGroup
-} from "../core/utils";
+} from "../../core/utils";
 import { PacificAtlanticInput } from "./types"; // Import PacificAtlanticInput
 
 // Removed PacificAtlanticInput interface definition


### PR DESCRIPTION
I corrected the relative import paths for the `utils.ts` module in several `steps.ts` files under `packages/backend/src/problem/free/`. The original paths (`../core/utils` or `../../../core/utils`) were incorrect based on the actual location of `utils.ts` at `packages/backend/src/problem/core/utils.ts`.

I changed paths in:
- container-with-most-water/steps.ts
- course-schedule/steps.ts
- longestIncreasingSubsequence/steps.ts
- merge-intervals/steps.ts
- minimumPathSum/steps.ts
- non-overlapping-intervals/steps.ts
- number-of-1-bits/steps.ts
- number-of-islands/steps.ts
- pacific-atlantic-water-flow/steps.ts

This resolves the "Cannot find module" errors.

Next, I re-evaluated the `SyntaxError: Export named 'VariableType' not found` related to `editDistance/problem.ts`. Further investigation would be needed to determine if this error persists after the path fixes and, if so, to locate the source of the `VariableType` usage or definition. My initial analysis showed that `VariableType` is not exported from `algo-lens-core` and is not directly used in `editDistance/problem.ts` or its immediate dependencies (`steps.ts`, `types.ts`).