### PR TITLE
Refactor: Standardize test structure for multiple problems

### DIFF
--- a/packages/backend/src/problem/free/bestTimeToBuyAndSellStocks/index.test.ts
+++ b/packages/backend/src/problem/free/bestTimeToBuyAndSellStocks/index.test.ts
@@ -1,0 +1,8 @@
+import { it } from "bun:test";
+import { problem } from "./problem"; // Assuming problem definition is exported from problem.ts
+import { runTests } from "../../core/test";
+import { testcases } from "./testcase"; // Import the renamed testcases
+
+it("bestTimeToBuyAndSellStocks", () => {
+  runTests(problem, testcases); // Pass both problem and testcases to runTests
+});

--- a/packages/backend/src/problem/free/bestTimeToBuyAndSellStocks/testcase.ts
+++ b/packages/backend/src/problem/free/bestTimeToBuyAndSellStocks/testcase.ts
@@ -1,11 +1,11 @@
-import { ProblemState, TestCase } from 'algo-lens-core';
-import { MaxProfitInput } from './types'; // Assuming MaxProfitInput is defined in types.ts
+import { ProblemState, TestCase } from "algo-lens-core";
+import { MaxProfitInput } from "./types"; // Assuming MaxProfitInput is defined in types.ts
 
-export const maxProfitTestCases: TestCase<MaxProfitInput, ProblemState>[] = [
-  { input: { prices: [2, 1, 2, 0, 1, 2] }, expected: { variables: [], breakpoint: 0 } },
-  { input: { prices: [7, 1, 5, 3, 6, 4] }, expected: { variables: [], breakpoint: 0 } },
-  { input: { prices: [7, 6, 4, 3, 1] }, expected: { variables: [], breakpoint: 0 } },
-  { input: { prices: [1, 2, 3, 4, 5] }, expected: { variables: [], breakpoint: 0 } },
-  { input: { prices: [1] }, expected: { variables: [], breakpoint: 0 } },
-  { input: { prices: [] }, expected: { variables: [], breakpoint: 0 } },
+export const testcases: TestCase<MaxProfitInput, ProblemState>[] = [
+  { input: { prices: [2, 1, 2, 0, 1, 2] }, expected: { variables: [{ label: "maxProfit", type: "number", value: 2 }] } },
+  { input: { prices: [7, 1, 5, 3, 6, 4] }, expected: { variables: [{ label: "maxProfit", type: "number", value: 5 }] } },
+  { input: { prices: [7, 6, 4, 3, 1] }, expected: { variables: [{ label: "maxProfit", type: "number", value: 0 }] } },
+  { input: { prices: [1, 2, 3, 4, 5] }, expected: { variables: [{ label: "maxProfit", type: "number", value: 4 }] } },
+  { input: { prices: [1] }, expected: { variables: [{ label: "maxProfit", type: "number", value: 0 }] } },
+  { input: { prices: [] }, expected: { variables: [{ label: "maxProfit", type: "number", value: 0 }] } },
 ];

--- a/packages/backend/src/problem/free/climbingStairs/index.test.ts
+++ b/packages/backend/src/problem/free/climbingStairs/index.test.ts
@@ -1,0 +1,8 @@
+import { it } from "bun:test";
+import { problem } from "./problem"; // Assuming problem definition is exported from problem.ts
+import { runTests } from "../../core/test";
+import { testcases } from "./testcase"; // Import the renamed testcases
+
+it("climbingStairs", () => {
+  runTests(problem, testcases); // Pass both problem and testcases to runTests
+});

--- a/packages/backend/src/problem/free/climbingStairs/testcase.ts
+++ b/packages/backend/src/problem/free/climbingStairs/testcase.ts
@@ -1,10 +1,10 @@
 
-import { ProblemState, TestCase } from 'algo-lens-core';
-import { ClimbingStairsInput } from './types'; // Assuming ClimbingStairsInput is defined in types.ts
-export const climbingStairsTestCases: TestCase<ClimbingStairsInput, {result:number}>[] = [
-  { input: { n: 5 }, expected: { result: 8 } },
-  { input: { n: 1 }, expected: { result: 1 } },
-  { input: { n: 2 }, expected: { result: 2 } },
-  { input: { n: 3 }, expected: { result: 3 } },
-  { input: { n: 8 }, expected: { result: 34 } },
+import { ProblemState, TestCase } from "algo-lens-core";
+import { ClimbingStairsInput } from "./types"; // Assuming ClimbingStairsInput is defined in types.ts
+export const testcases: TestCase<ClimbingStairsInput, ProblemState>[] = [
+  { input: { n: 5 }, expected: { variables: [{ label: "result", type: "number", value: 8 }] } },
+  { input: { n: 1 }, expected: { variables: [{ label: "result", type: "number", value: 1 }] } },
+  { input: { n: 2 }, expected: { variables: [{ label: "result", type: "number", value: 2 }] } },
+  { input: { n: 3 }, expected: { variables: [{ label: "result", type: "number", value: 3 }] } },
+  { input: { n: 8 }, expected: { variables: [{ label: "result", type: "number", value: 34 }] } },
 ];

--- a/packages/backend/src/problem/free/coinChange/index.test.ts
+++ b/packages/backend/src/problem/free/coinChange/index.test.ts
@@ -1,0 +1,8 @@
+import { it } from "bun:test";
+import { problem } from "./problem"; // Assuming problem definition is exported from problem.ts
+import { runTests } from "../../core/test";
+import { testcases } from "./testcase"; // Import the renamed testcases
+
+it("coinChange", () => {
+  runTests(problem, testcases); // Pass both problem and testcases to runTests
+});

--- a/packages/backend/src/problem/free/coinChange/testcase.ts
+++ b/packages/backend/src/problem/free/coinChange/testcase.ts
@@ -1,11 +1,11 @@
-import { TestCase } from '../../problem.types';
-import { CoinChangeInput } from './types'; // Assuming CoinChangeInput is defined in types.ts
+import { ProblemState, TestCase } from "algo-lens-core";
+import { CoinChangeInput } from "./types"; // Assuming CoinChangeInput is defined in types.ts
 
-export const coinChangeTestCases: TestCase<CoinChangeInput, number>[] = [
-  { input: { coins: [1, 2, 5], target: 11 }, expected: 3 },
-  { input: { coins: [2], target: 3 }, expected: -1 },
-  { input: { coins: [1], target: 0 }, expected: 0 },
-  { input: { coins: [1], target: 1 }, expected: 1 },
-  { input: { coins: [1], target: 2 }, expected: 2 },
-  { input: { coins: [186, 419, 83, 408], target: 6249 }, expected: 20 },
+export const testcases: TestCase<CoinChangeInput, ProblemState>[] = [
+  { input: { coins: [1, 2, 5], target: 11 }, expected: { variables: [{ label: "result", type: "number", value: 3 }] } },
+  { input: { coins: [2], target: 3 }, expected: { variables: [{ label: "result", type: "number", value: -1 }] } },
+  { input: { coins: [1], target: 0 }, expected: { variables: [{ label: "result", type: "number", value: 0 }] } },
+  { input: { coins: [1], target: 1 }, expected: { variables: [{ label: "result", type: "number", value: 1 }] } },
+  { input: { coins: [1], target: 2 }, expected: { variables: [{ label: "result", type: "number", value: 2 }] } },
+  { input: { coins: [186, 419, 83, 408], target: 6249 }, expected: { variables: [{ label: "result", type: "number", value: 20 }] } },
 ];

--- a/packages/backend/src/problem/free/containsDuplicate/index.test.ts
+++ b/packages/backend/src/problem/free/containsDuplicate/index.test.ts
@@ -1,0 +1,9 @@
+import { it } from "bun:test";
+import { problem } from "./problem"; 
+import { runTests } from "../../core/test";
+import { testcases } from "./testcase"; 
+
+it("containsDuplicate", () => {
+  // Assuming runTests can handle comparing final ProblemState variables
+  runTests(problem, testcases); 
+});

--- a/packages/backend/src/problem/free/containsDuplicate/testcase.ts
+++ b/packages/backend/src/problem/free/containsDuplicate/testcase.ts
@@ -1,0 +1,39 @@
+import { ProblemState, TestCase, BooleanVariable } from 'algo-lens-core';
+import { ContainsDuplicateInput } from './types';
+
+// Define a few basic test cases
+export const testcases: TestCase<ContainsDuplicateInput, ProblemState>[] = [
+  {
+    input: { nums: [1, 2, 3, 1] }, // Contains duplicate
+    expected: {
+      variables: [
+        // Assuming the final boolean result is stored in a variable named 'result'
+        { label: "result", type: "boolean", value: true } as BooleanVariable 
+      ]
+    }
+  },
+  {
+    input: { nums: [1, 2, 3, 4] }, // No duplicates
+    expected: {
+      variables: [
+        { label: "result", type: "boolean", value: false } as BooleanVariable
+      ]
+    }
+  },
+  {
+    input: { nums: [] }, // Empty array
+    expected: {
+      variables: [
+        { label: "result", type: "boolean", value: false } as BooleanVariable
+      ]
+    }
+  },
+  {
+    input: { nums: [1, 1, 1, 1] }, // All duplicates
+    expected: {
+      variables: [
+        { label: "result", type: "boolean", value: true } as BooleanVariable
+      ]
+    }
+  }
+];

--- a/packages/backend/src/problem/free/countingBits/index.test.ts
+++ b/packages/backend/src/problem/free/countingBits/index.test.ts
@@ -1,0 +1,9 @@
+import { it } from "bun:test";
+import { problem } from "./problem"; 
+import { runTests } from "../../core/test";
+import { testcases } from "./testcase"; 
+
+it("countingBits", () => {
+  // Assuming runTests can handle comparing final ProblemState variables (like the result array)
+  runTests(problem, testcases); 
+});

--- a/packages/backend/src/problem/free/countingBits/testcase.ts
+++ b/packages/backend/src/problem/free/countingBits/testcase.ts
@@ -1,0 +1,33 @@
+import { ProblemState, TestCase, ArrayVariable } from 'algo-lens-core';
+import { CountBitsInput } from './types';
+
+// Define test cases for countingBits
+export const testcases: TestCase<CountBitsInput, ProblemState>[] = [
+  {
+    input: { n: 2 }, // Input n = 2
+    expected: {
+      variables: [
+        // Expected output: [0, 1, 1] (bits in 0, 1, 2)
+        { label: "result", type: "array", value: [0, 1, 1] } as ArrayVariable 
+      ]
+    }
+  },
+  {
+    input: { n: 5 }, // Input n = 5
+    expected: {
+      variables: [
+        // Expected output: [0, 1, 1, 2, 1, 2] (bits in 0, 1, 2, 3, 4, 5)
+        { label: "result", type: "array", value: [0, 1, 1, 2, 1, 2] } as ArrayVariable
+      ]
+    }
+  },
+  {
+    input: { n: 0 }, // Input n = 0
+    expected: {
+      variables: [
+        // Expected output: [0] (bits in 0)
+        { label: "result", type: "array", value: [0] } as ArrayVariable
+      ]
+    }
+  }
+];

--- a/packages/backend/src/problem/free/course-schedule/index.test.ts
+++ b/packages/backend/src/problem/free/course-schedule/index.test.ts
@@ -1,0 +1,8 @@
+import { it } from "bun:test";
+import { problem } from "./problem"; 
+import { runTests } from "../../core/test";
+import { testcases } from "./testcase"; 
+
+it("courseSchedule", () => {
+  runTests(problem, testcases); 
+});

--- a/packages/backend/src/problem/free/course-schedule/problem.ts
+++ b/packages/backend/src/problem/free/course-schedule/problem.ts
@@ -29,27 +29,6 @@ export const problem: Problem<CourseScheduleInput, ProblemState> = {
   title: title,
   emoji: "📚",
   code: code, // Use the imported code string
-  testcases: [
-    {
-      input: {
-        numCourses: 10,
-        prerequisites: [
-          [1, 0],
-          [2, 0],
-          [3, 1],
-          [3, 2],
-          [4, 2],
-          [5, 3],
-          [5, 4],
-          [6, 0],
-          [7, 6],
-          [8, 7],
-          [9, 8],
-        ],
-      },
-      expected: {},
-    },
-  ],
   func: courseSchedule, // Use the imported algorithm function
   id: "course-schedule",
   tags: ["graph", "bfs", "topological-sort"],

--- a/packages/backend/src/problem/free/course-schedule/testcase.ts
+++ b/packages/backend/src/problem/free/course-schedule/testcase.ts
@@ -1,0 +1,38 @@
+import { ProblemState, TestCase, BooleanVariable } from 'algo-lens-core';
+import { CourseScheduleInput } from './types';
+
+export const testcases: TestCase<CourseScheduleInput, ProblemState>[] = [
+  { // Original test case (assuming it's possible)
+    input: {
+      numCourses: 10,
+      prerequisites: [ [1, 0], [2, 0], [3, 1], [3, 2], [4, 2], [5, 3], [5, 4], [6, 0], [7, 6], [8, 7], [9, 8] ],
+    },
+    expected: { // Expecting true (schedule possible)
+      variables: [ { label: "result", type: "boolean", value: true } as BooleanVariable ]
+    }
+  },
+  { // Simple possible schedule
+    input: { numCourses: 2, prerequisites: [[1, 0]] },
+    expected: { // Expecting true
+      variables: [ { label: "result", type: "boolean", value: true } as BooleanVariable ]
+    }
+  },
+  { // Simple impossible schedule (cycle)
+    input: { numCourses: 2, prerequisites: [[1, 0], [0, 1]] },
+    expected: { // Expecting false
+      variables: [ { label: "result", type: "boolean", value: false } as BooleanVariable ]
+    }
+  },
+  { // No prerequisites
+    input: { numCourses: 3, prerequisites: [] },
+    expected: { // Expecting true
+      variables: [ { label: "result", type: "boolean", value: true } as BooleanVariable ]
+    }
+  },
+  { // More complex impossible schedule
+     input: { numCourses: 4, prerequisites: [[1,0],[2,1],[3,2],[1,3]] },
+     expected: { // Expecting false (cycle 1->2->3->1)
+         variables: [ { label: "result", type: "boolean", value: false } as BooleanVariable ]
+     }
+  }
+];


### PR DESCRIPTION
This commit standardizes the test case structure and adds test runner files (`index.test.ts`) for several algorithm problems within `packages/backend/src/problem/free/`, following the pattern established by the `3sum` problem.