### PR TITLE
Fix: Use label instead of title in GroupMetadata

### DIFF
--- a/packages/backend/src/problem/free/course-schedule/groups.ts
+++ b/packages/backend/src/problem/free/course-schedule/groups.ts
@@ -3,34 +3,25 @@ import { GroupMetadata } from "algo-lens-core";
 // Define groups for visualizing the Course Schedule problem state
 export const courseScheduleGroups: GroupMetadata[] = [
   {
-    id: "input",
-    title: "Input",
-    variables: ["numCourses", "prerequisites"],
+    label: "Input",
     emoji: "📥",
   },
   {
-    id: "state",
-    title: "Algorithm State",
-    variables: ["graph", "inDegree", "queue", "count"],
+    label: "Algorithm State",
     emoji: "📊",
   },
   {
-    id: "processing",
-    title: "Current Processing",
-    variables: ["current", "neighbor", "prev"], // Added 'prev' based on logStep usage
+    label: "Current Processing",
+    // variables: ["current", "neighbor", "prev"], // Added 'prev' based on logStep usage
     emoji: "⚙️",
   },
   {
-    id: "result",
-    title: "Result",
-    variables: ["allCoursesTaken"],
+    label: "Result",
     emoji: "🏁",
   },
   // Add other potential simple value variables used in logging
   {
-      id: "tempValues",
-      title: "Temporary Values",
-      variables: ["course", "prereq", "deg"],
+      label: "Temporary Values",
       emoji: "🧪",
   }
 ];

--- a/packages/backend/src/problem/free/course-schedule/groups.ts
+++ b/packages/backend/src/problem/free/course-schedule/groups.ts
@@ -3,24 +3,29 @@ import { GroupMetadata } from "algo-lens-core";
 // Define groups for visualizing the Course Schedule problem state
 export const courseScheduleGroups: GroupMetadata[] = [
   {
+    name: "input",
     label: "Input",
     emoji: "📥",
   },
   {
+    name: "state",
     label: "Algorithm State",
     emoji: "📊",
   },
   {
+    name: "processing",
     label: "Current Processing",
     // variables: ["current", "neighbor", "prev"], // Added 'prev' based on logStep usage
     emoji: "⚙️",
   },
   {
+    name: "result",
     label: "Result",
     emoji: "🏁",
   },
   // Add other potential simple value variables used in logging
   {
+      name: "tempValues",
       label: "Temporary Values",
       emoji: "🧪",
   }

--- a/packages/backend/src/problem/free/editDistance/groups.ts
+++ b/packages/backend/src/problem/free/editDistance/groups.ts
@@ -1,8 +1,8 @@
 import { GroupMetadata } from "algo-lens-core";
 
 export const groups: GroupMetadata[] = [
-  { label: "Inputs", emoji: "📥" },
-  { label: "DP Table", emoji: "📊" },
-  { label: "Loop Variables", emoji: "🔁" },
-  { label: "Result", emoji: "🏁" },
+  { name: "inputs", label: "Inputs", emoji: "📥" },
+  { name: "dpTable", label: "DP Table", emoji: "📊" },
+  { name: "loopVariables", label: "Loop Variables", emoji: "🔁" },
+  { name: "result", label: "Result", emoji: "🏁" },
 ];

--- a/packages/backend/src/problem/free/editDistance/groups.ts
+++ b/packages/backend/src/problem/free/editDistance/groups.ts
@@ -1,8 +1,8 @@
 import { GroupMetadata } from "algo-lens-core";
 
 export const groups: GroupMetadata[] = [
-  { title: "Inputs", variables: ["s1", "s2"], emoji: "📥" },
-  { title: "DP Table", variables: ["dp"], emoji: "📊" },
-  { title: "Loop Variables", variables: ["i", "j", "op"], emoji: "🔁" },
-  { title: "Result", variables: ["result", "s1Length", "s2Length"], emoji: "🏁" },
+  { label: "Inputs", emoji: "📥" },
+  { label: "DP Table", emoji: "📊" },
+  { label: "Loop Variables", emoji: "🔁" },
+  { label: "Result", emoji: "🏁" },
 ];

--- a/packages/backend/src/problem/free/houseRobber/groups.ts
+++ b/packages/backend/src/problem/free/houseRobber/groups.ts
@@ -1,7 +1,7 @@
 import { GroupMetadata } from "algo-lens-core";
 
 export const groups: GroupMetadata[] = [
-  { name: "dpCalculation", title: "DP Calculation", emoji: "💰" },
-  { name: "loopInfo", title: "Loop Info", emoji: "🔁" },
-  { name: "result", title: "Result", emoji: "🏁" }, // Added for final result
+  { name: "dpCalculation", label: "DP Calculation", emoji: "💰" },
+  { name: "loopInfo", label: "Loop Info", emoji: "🔁" },
+  { name: "result", label: "Result", emoji: "🏁" }, // Added for final result
 ];


### PR DESCRIPTION
Several `groups.ts` files were using `title` instead of `label` for the group name, contrary to the `GroupMetadata` interface defined in `algo-lens-core`.

This commit corrects the following files:
- packages/backend/src/problem/free/course-schedule/groups.ts
- packages/backend/src/problem/free/editDistance/groups.ts
- packages/backend/src/problem/free/houseRobber/groups.ts

Additionally, invalid properties (`id`, `variables`) that were present in some of these definitions have been removed to ensure full conformance with the `GroupMetadata` interface.