### PR TITLE
feat: Add missing test files to problem folders

### DIFF
--- a/packages/backend/src/problem/free/editDistance/index.test.ts
+++ b/packages/backend/src/problem/free/editDistance/index.test.ts
@@ -1,0 +1,7 @@
+import { it } from "bun:test";
+import { problem } from "./problem";
+import { runTests } from "../../core/test";
+
+it("editDistance", () => {
+  runTests(problem);
+});

--- a/packages/backend/src/problem/free/editDistance/testcase.ts
+++ b/packages/backend/src/problem/free/editDistance/testcase.ts
@@ -1,0 +1,4 @@
+import { TestCase, ProblemState } from "algo-lens-core";
+import { EditDistanceInput } from "./types";
+
+export const testcases: TestCase<EditDistanceInput, ProblemState>[] = [];

--- a/packages/backend/src/problem/free/houseRobber/index.test.ts
+++ b/packages/backend/src/problem/free/houseRobber/index.test.ts
@@ -1,0 +1,7 @@
+import { it } from "bun:test";
+import { problem } from "./problem";
+import { runTests } from "../../core/test";
+
+it("houseRobber", () => {
+  runTests(problem);
+});

--- a/packages/backend/src/problem/free/houseRobber/testcase.ts
+++ b/packages/backend/src/problem/free/houseRobber/testcase.ts
@@ -1,0 +1,4 @@
+import { TestCase, ProblemState } from "algo-lens-core";
+import { HouseRobberInput } from "./types";
+
+export const testcases: TestCase<HouseRobberInput, ProblemState>[] = [];

--- a/packages/backend/src/problem/free/insert-interval/index.test.ts
+++ b/packages/backend/src/problem/free/insert-interval/index.test.ts
@@ -1,0 +1,7 @@
+import { it } from "bun:test";
+import { problem } from "./problem";
+import { runTests } from "../../core/test";
+
+it("insert-interval", () => {
+  runTests(problem);
+});

--- a/packages/backend/src/problem/free/insert-interval/testcase.ts
+++ b/packages/backend/src/problem/free/insert-interval/testcase.ts
@@ -1,0 +1,4 @@
+import { TestCase, ProblemState } from "algo-lens-core";
+import { InsertIntervalInput } from "./types";
+
+export const testcases: TestCase<InsertIntervalInput, ProblemState>[] = [];

--- a/packages/backend/src/problem/free/maximum-subarray/index.test.ts
+++ b/packages/backend/src/problem/free/maximum-subarray/index.test.ts
@@ -1,0 +1,7 @@
+import { it } from "bun:test";
+import { problem } from "./problem";
+import { runTests } from "../../core/test";
+
+it("maximum-subarray", () => {
+  runTests(problem);
+});

--- a/packages/backend/src/problem/free/maximum-subarray/testcase.ts
+++ b/packages/backend/src/problem/free/maximum-subarray/testcase.ts
@@ -1,0 +1,4 @@
+import { TestCase, ProblemState } from "algo-lens-core";
+import { MaximumSubarrayInput } from "./types";
+
+export const testcases: TestCase<MaximumSubarrayInput, ProblemState>[] = [];

--- a/packages/backend/src/problem/free/missingNumber/index.test.ts
+++ b/packages/backend/src/problem/free/missingNumber/index.test.ts
@@ -1,0 +1,7 @@
+import { it } from "bun:test";
+import { problem } from "./problem";
+import { runTests } from "../../core/test";
+
+it("missingNumber", () => {
+  runTests(problem);
+});

--- a/packages/backend/src/problem/free/missingNumber/testcase.ts
+++ b/packages/backend/src/problem/free/missingNumber/testcase.ts
@@ -1,0 +1,4 @@
+import { TestCase, ProblemState } from "algo-lens-core";
+import { MissingNumberInput } from "./types";
+
+export const testcases: TestCase<MissingNumberInput, ProblemState>[] = [];


### PR DESCRIPTION
Adds the standard `index.test.ts` and a placeholder `testcase.ts` to the following problem folders under `packages/backend/src/problem/free/` which were previously missing them:

- editDistance
- houseRobber
- insert-interval
- maximum-subarray
- missingNumber

The `index.test.ts` files include the standard test runner setup. The `testcase.ts` files import the necessary types and export an empty `testcases` array, providing the correct structure for future test case additions.