### PR TITLE
Refactor: Standardize variable exports in backend problems

### DIFF
--- a/packages/backend/src/problem/free/editDistance/variables.ts
+++ b/packages/backend/src/problem/free/editDistance/variables.ts
@@ -1,6 +1,6 @@
 import { VariableMetadata } from "algo-lens-core"; // Updated import
 
-export const variables: VariableMetadata[] = [
+export const variableMetadata: VariableMetadata[] = [
   // Changed to array
   {
     name: "dp", // Key became name

--- a/packages/backend/src/problem/free/pacific-atlantic-water-flow/variables.ts
+++ b/packages/backend/src/problem/free/pacific-atlantic-water-flow/variables.ts
@@ -1,1 +1,3 @@
-// Placeholder for variable definitions, if needed in the future.
+import { VariableMetadata } from "algo-lens-core";
+
+export const variableMetadata: VariableMetadata[] = [];


### PR DESCRIPTION
Ensures that all existing `variables.ts` files within the `packages/backend/src/problem/free/` subdirectories consistently export a constant named `variableMetadata`.

- Renamed the export in `editDistance/variables.ts` from `variables` to `variableMetadata`.
- Added a standard empty `variableMetadata` export to the placeholder file in `pacific-atlantic-water-flow/variables.ts`.

This improves consistency across problem definitions.