### PR TITLE
Fix(coinChange): Correct expected value in test case

### DIFF
--- a/packages/backend/src/problem/free/coinChange/testcase.ts
+++ b/packages/backend/src/problem/free/coinChange/testcase.ts
@@ -4,6 +4,6 @@ export const testcases: TestCase<[number[], number], number>[] = [
   { input: [[1, 2, 5], 11], expected: 3 },
   { input: [[1], 2], expected: 2 },
   { input: [[186, 419, 83, 408], 6249], expected: 20 },
-  { input: [[1, 2, 5], 7], expected: 3 },
+  { input: [[1, 2, 5], 7], expected: 2 },
   { input: [[1, 2, 5], 6], expected: 2 },
 ];


### PR DESCRIPTION
The test case for the input coins = [1, 2, 5], target = 7 incorrectly expected 3 coins as the minimum. The actual minimum number of coins required is 2 (one 5 coin and one 2 coin).

This commit updates the expected value in the test case data from 3 to 2 to align with the correct solution for the coin change problem.