### PR TITLE
Refactor: Use StepLoggerV2 in number-of-islands steps

### DIFF
--- a/packages/backend/src/problem/free/number-of-islands/steps.ts
+++ b/packages/backend/src/problem/free/number-of-islands/steps.ts
@@ -1,15 +1,16 @@
 // Imports specific utility functions and type definitions from the relative paths
 import { cloneDeep } from "lodash";
 import { ProblemState, Variable } from "algo-lens-core"; // Removed Problem
+import { StepLoggerV2 } from "../../core/StepLoggerV2"; // Import StepLoggerV2
 import { as2dArray, asValueGroup, deepClone2DArray } from "../../core/utils";
 import { NumIslandsInput } from "./types"; // Import NumIslandsInput
 
 // Removed duplicate NumIslandsInput interface definition
 
 export function generateSteps(p: NumIslandsInput): ProblemState[] { // Renamed and Exported
+  const l = new StepLoggerV2();
   const { grid } = p;
   const clonedGrid = deepClone2DArray(grid); // Use the deep clone for operations
-  const steps: ProblemState[] = [];
   let numIslands = 0;
   const rowCount = clonedGrid.length;
   const colCount = clonedGrid[0].length;
@@ -20,21 +21,14 @@ export function generateSteps(p: NumIslandsInput): ProblemState[] { // Renamed a
     [0, 1],
   ];
 
-  function log(point: number, i?: number, j?: number) {
-    console.log("log", point, JSON.stringify(clonedGrid));
-    const v: Variable[] = [];
-    const step: ProblemState = {
-      variables: v,
-      breakpoint: point,
-    };
-    v.push(as2dArray("grid", (clonedGrid), [{ r: i, c: j }]));
-    v.push(asValueGroup("counter", { numIslands }, { max: (rowCount * colCount) / 2, min: 0 }));
-    steps.push(step);
-  }
-  log(1);
+  l.breakpoint(1);
+  l.grid('grid', clonedGrid);
+  l.variables('counter', { numIslands }, { max: (rowCount * colCount) / 2, min: 0 });
 
   function dfs(i: number, j: number) {
-    log(2, i, j);
+    l.breakpoint(2);
+    l.grid('grid', clonedGrid, [{ r: i, c: j }]);
+    l.variables('counter', { numIslands }, { max: (rowCount * colCount) / 2, min: 0 });
     if (i < 0 || i >= rowCount || j < 0 || j >= colCount || clonedGrid[i][j] !== '1') {
       return;
     }
@@ -46,17 +40,20 @@ export function generateSteps(p: NumIslandsInput): ProblemState[] { // Renamed a
 
   for (let i = 0; i < rowCount; i++) {
     for (let j = 0; j < colCount; j++) {
-      log(8,i,j);
+      l.breakpoint(8);
+      l.grid('grid', clonedGrid, [{ r: i, c: j }]);
+      l.variables('counter', { numIslands }, { max: (rowCount * colCount) / 2, min: 0 });
       if (clonedGrid[i][j] === '1') {
-        log(9,i,j);
+        l.breakpoint(9);
+        l.grid('grid', clonedGrid, [{ r: i, c: j }]);
+        l.variables('counter', { numIslands }, { max: (rowCount * colCount) / 2, min: 0 });
         numIslands++;
         dfs(i, j);
       }
     }
   }
 
-  console.log("steps", steps);
-  return steps;
+  return l.getSteps();
 }
 
 // Removed code, title, getInput, Problem export


### PR DESCRIPTION
I replaced the custom logging implementation in packages/backend/src/problem/free/number-of-islands/steps.ts with the standard StepLoggerV2.

This involved:
- Importing StepLoggerV2.
- Instantiating the logger.
- Replacing manual step creation and variable logging with calls to logger methods (l.grid, l.variables, l.breakpoint).
- Returning steps using l.getSteps().
- Removing the old unused log function and steps array.