### PR TITLE
Refactor: Use StepLoggerV2 in product-of-array-except-self

### DIFF
--- a/packages/backend/src/problem/free/product-of-array-except-self/steps.ts
+++ b/packages/backend/src/problem/free/product-of-array-except-self/steps.ts
@@ -1,84 +1,65 @@
 // Imports specific utility functions and type definitions from the relative paths
-import { ProblemState, Variable } from "algo-lens-core";
+import { ProblemState } from "algo-lens-core"; // Import ProblemState
+import { StepLoggerV2 } from "../core/StepLoggerV2";
 import { ProductExceptSelfInput } from "./types"; // Import the interface
-import { asArray } from "../../core/utils";
 
 /**
  * Implements the product of array except self algorithm which calculates the product of all numbers in the input array except for the number at each index, generating steps for visualization.
- * @param p - The input parameters including an array of numbers.
+ * @param nums - The input array of numbers.
  * @returns An array of ProblemState capturing each step of the computation for visualization.
  */
 export function generateSteps(nums: number[]): ProblemState[] {
-  const steps: ProblemState[] = [];
+  const logger = new StepLoggerV2();
   const length = nums.length;
   const output: number[] = new Array(length).fill(1);
   // Create the left (prefix) and right (suffix) products arrays
   const productsLeft: number[] = new Array(length).fill(1);
   const productsRight: number[] = new Array(length).fill(1);
 
-  // Helper function to create and log each step's computational state
-  function log(p: {
-    point: number;
-    numsIndex?: number[];
-    leftIndex?: number[];
-    rightIndex?: number[];
-    outputIndex?: number[];
-  }) {
-    const v: Variable[] = [];
-    const { point, numsIndex, leftIndex, rightIndex, outputIndex } = p;
-    const step: ProblemState = {
-      variables: v,
-      breakpoint: point,
-    };
-    v.push(asArray("nums", nums, ...(numsIndex ?? [])));
-    if (productsLeft) {
-      v.push(asArray("productsLeft", productsLeft, ...(leftIndex ?? [])));
-    }
-    if (productsRight) {
-      v.push(asArray("productsRight", productsRight, ...(rightIndex ?? [])));
-    }
-    if (output) {
-      v.push(asArray("output", output, ...(outputIndex ?? [])));
-    }
-    steps.push(step);
-  }
-
-  // Initial state log before the loop starts
-  log({ point: 1 });
+  // Log the initial state
+  logger.array("nums", nums);
+  logger.array("productsLeft", productsLeft);
+  logger.array("productsRight", productsRight);
+  logger.array("output", output);
+  logger.breakpoint(1);
 
   // Fill productsLeft array (prefix products)
   for (let i = 1; i < length; i++) {
     productsLeft[i] = productsLeft[i - 1] * nums[i - 1];
-    log({ point: 2, leftIndex: [i, i - 1], numsIndex: [i - 1] });
+    logger.array("nums", nums, { pointer: [i - 1] });
+    logger.array("productsLeft", productsLeft, { pointer: [i, i - 1] });
+    logger.array("productsRight", productsRight);
+    logger.array("output", output);
+    logger.breakpoint(2);
   }
 
   // Fill productsRight array (suffix products)
   for (let i = length - 2; i >= 0; i--) {
     productsRight[i] = productsRight[i + 1] * nums[i + 1];
-    log({ point: 3, rightIndex: [i, i + 1], numsIndex: [i + 1] });
+    logger.array("nums", nums, { pointer: [i + 1] });
+    logger.array("productsLeft", productsLeft);
+    logger.array("productsRight", productsRight, { pointer: [i, i + 1] });
+    logger.array("output", output);
+    logger.breakpoint(3);
   }
 
   // Calculate the output array by combining prefix and suffix products
   for (let i = 0; i < length; i++) {
     output[i] = productsLeft[i] * productsRight[i];
-    log({ point: 4, outputIndex: [i], leftIndex: [i], rightIndex: [i] });
+    logger.array("nums", nums);
+    logger.array("productsLeft", productsLeft, { pointer: [i] });
+    logger.array("productsRight", productsRight, { pointer: [i] });
+    logger.array("output", output, { pointer: [i] });
+    logger.breakpoint(4);
   }
 
-  // Logs the final state with the output array
-  log({ point: 5 });
+  // Log the final state with the result
+  logger.array("result", output);
+  logger.hide("nums");
+  logger.hide("productsLeft");
+  logger.hide("productsRight");
+  logger.hide("output");
+  logger.breakpoint(5);
 
-  // Ensure the final step has the 'result' variable
-  if (steps.length > 0) {
-    const lastStep = steps[steps.length - 1];
-    // Check if 'result' already exists, if not, add it.
-    // It's safer to remove any existing 'output' variable first if the test expects ONLY 'result'
-    // For now, let's just add 'result'. Consider refining if tests still fail.
-    const resultVar = asArray("result", output); // Use the final 'output' array
-    lastStep.variables.push(resultVar);
-
-    // Optional: Remove the 'output' variable from the last step if it causes issues
-    // lastStep.variables = lastStep.variables.filter(v => v.label !== 'output');
-  }
-
-  return steps;
+  return logger.getSteps();
 }


### PR DESCRIPTION
I replaced the manual step generation logic in
`packages/backend/src/problem/free/product-of-array-except-self/steps.ts` with the standardized `StepLoggerV2`.

This involves:
- Importing and instantiating `StepLoggerV2`.
- Using `logger.array()` to track the state of 'nums', 'productsLeft', 'productsRight', and 'output' arrays.
- Using pointer arguments in `logger.array()` to indicate highlighted indices.
- Using `logger.breakpoint()` to mark distinct steps in the algorithm.
- Logging the final 'result' array and hiding intermediate arrays in the last step.
- Returning the steps generated by `logger.getSteps()`.

This change aligns the problem implementation with the preferred logging mechanism. I could not run tests due to environment limitations.