### PR TITLE
Fix: Define missing group options for "loop" in missingNumber steps

### DIFF
--- a/packages/backend/src/problem/free/missingNumber/steps.ts
+++ b/packages/backend/src/problem/free/missingNumber/steps.ts
@@ -10,6 +10,7 @@ export function generateSteps(nums: number[]): ProblemState[] {
   const n = nums.length;
   const expectedSum = (n * (n + 1)) / 2;
   l.groupOptions.set("sum", { min: 0, max: expectedSum, reverse: false });
+  l.groupOptions.set("loop", { min: 0, max: n });
   let actualSum = 0;
 
   // Breakpoint 1: Initial state


### PR DESCRIPTION
The StepLoggerV2 requires options (like min/max) to be defined for a group before logging it using `logger.group()`. The `generateSteps` function for the `missingNumber` problem was logging the "loop" group (containing the loop index `i`) without first defining its options via `logger.groupOptions.set("loop", ...)`.

This commit adds the necessary `l.groupOptions.set("loop", { min: 0, max: n });` line before the loop in `packages/backend/src/problem/free/missingNumber/steps.ts` to resolve the "no options for this group: loop" error.