### PR TITLE
Fix(test): Correct argument passing in runTests for coinChange

### DIFF
--- a/packages/backend/src/problem/core/test.ts
+++ b/packages/backend/src/problem/core/test.ts
@@ -25,7 +25,7 @@ export function runTests(problem: Problem<any, ProblemState>) {
   for (const testcase of problem.testcases) {
     const input = cloneDeep(testcase.input);
     const expected = cloneDeep(testcase.expected);
-    const states = problem.func(input);
+    const states = problem.func(...input);
     const state = last(states);
     const variables = state!.variables;
     const result = variables.find((x) => x.label === "result");


### PR DESCRIPTION
The runTests helper function was incorrectly passing the input tuple (e.g., `[coins, target]`) as a single argument to the problem function (`generateSteps` for coinChange). This resulted in the `target` parameter being undefined within `generateSteps`.

Consequently, the line `new Array(target + 1)` evaluated to `new Array(NaN)`, causing a RangeError.

This commit fixes the issue by using the spread operator (`...input`) in `runTests` to correctly pass the elements of the input tuple as distinct arguments to the problem function.