### PR TITLE
fix(test): Correct expected value in product-of-array-except-self test

### DIFF
--- a/packages/backend/src/problem/free/product-of-array-except-self/testcase.ts
+++ b/packages/backend/src/problem/free/product-of-array-except-self/testcase.ts
@@ -4,7 +4,7 @@ import { ProductExceptSelfInput } from "./types";
 export const testcases: TestCase<ProductExceptSelfInput, any>[] = [
   {
     input: [1, 2, 3, 4, 5],
-    expected: 120,
+    expected: [ 120, 60, 40, 30, 24 ],
   },
   // Add more test cases here if needed
   {


### PR DESCRIPTION
The test case for the input [1, 2, 3, 4, 5] incorrectly expected the output to be the single number 120.

This commit updates the expected value to the correct array [ 120, 60, 40, 30, 24 ], aligning it with the problem's requirements and the actual function output.