### PR TITLE
fix(problem): Add missing variable metadata for containsDuplicate

### DIFF
--- a/packages/backend/src/problem/free/containsDuplicate/problem.ts
+++ b/packages/backend/src/problem/free/containsDuplicate/problem.ts
@@ -3,6 +3,7 @@ import { Problem, ProblemState } from "algo-lens-core";
 import { ContainsDuplicateInput } from "./types"; // New import
 import { generateSteps } from "./steps";
 import { testcases } from "./testcase";
+import { variables } from "./variables";
 
 // Description for a larger, more complex input set to test and visualize the algorithm
 const title = "Contains Duplicate";
@@ -17,7 +18,7 @@ export const problem: Problem<ContainsDuplicateInput, ProblemState> = {
   tags: ["hashset"],
   difficulty: "medium",
   metadata: {
-    groups: [],
-    variables: [],
+    groups: [], // Keep groups as empty for now, unless defined elsewhere
+    variables, // Use the imported variables
   },
 };

--- a/packages/backend/src/problem/free/containsDuplicate/variables.ts
+++ b/packages/backend/src/problem/free/containsDuplicate/variables.ts
@@ -1,0 +1,20 @@
+import { VariableMetadata } from "algo-lens-core";
+
+export const variables: VariableMetadata[] = [
+  {
+    name: "nums",
+    description: "The input array of numbers.",
+    emoji: "🔢", // Using the same emoji as 3sum for consistency
+  },
+  {
+    name: "result",
+    description: "Boolean indicating if the array contains duplicate elements.",
+    emoji: "✅", // Using the same emoji as 3sum for the result
+  },
+  // Add other relevant variables if needed based on steps.ts, e.g., a hash set
+  {
+    name: "seen",
+    description: "Hash set to store numbers encountered so far.",
+    emoji: "🔍"
+  }
+];


### PR DESCRIPTION
The test suite for the 'containsDuplicate' problem was failing because the problem definition in `problem.ts` had an empty `variables` array in its metadata. The test runner (`core/test.ts`) requires this array to be populated.

This commit fixes the issue by:
1. Creating a new `variables.ts` file defining the necessary variables (input `nums`, result, and internal `seen` set).
2. Updating `problem.ts` to import and use these variables in its metadata object, mirroring the structure used by other problems like '3sum'.

This resolves the "No variables found in metadata" error during testing.