### PR TITLE
fix(missingNumber): Correct result logging for test compatibility

### DIFF
--- a/packages/backend/src/problem/free/missingNumber/steps.ts
+++ b/packages/backend/src/problem/free/missingNumber/steps.ts
@@ -36,8 +36,8 @@ export function generateSteps(nums: number[]): ProblemState[] {
   l.breakpoint(3);
   l.array("nums", nums); // Log final array state
   l.group("sum", { expectedSum, actualSum, result }); // Log final sums and result
-  // Optionally log result as simple value if not included in 'sum' group
-  l.simple({ result });
+  // Log the result variable explicitly
+  l.variable("result", result);
 
   return l.getSteps(); // Return the generated steps
 }


### PR DESCRIPTION
The test runner expects the final result of a problem's execution to be available as a top-level variable with the label "result" in the last state's variables array.

The `missingNumber` problem's `generateSteps` function previously used `l.simple({ result })` or logged the result within a group, which did not place the variable correctly for the test runner (`core/test.ts`).

This change modifies `missingNumber/steps.ts` to use `l.variable("result", result)` in the final step, mirroring the pattern used in other problems like `3sum` (`l.array2d("result", ...)`). This ensures the result variable is logged in the expected format.

Note: Test execution environment was unavailable, so this fix could not be programmatically verified.