### PR TITLE
Fix(climbingStairs): Correct RangeError in generateSteps

### DIFF
--- a/packages/backend/src/problem/free/climbingStairs/steps.ts
+++ b/packages/backend/src/problem/free/climbingStairs/steps.ts
@@ -6,33 +6,32 @@ import { StepLoggerV2 } from "../../core/StepLoggerV2";
 
 export function generateSteps(p: ClimbingStairsInput): ProblemState[] {
   const l = new StepLoggerV2();
-  const { n } = p;
 
   // Initialize dp array
-  const dp: number[] = new Array(n + 1).fill(0);
+  const dp: number[] = new Array(p + 1).fill(0);
   dp[0] = 1;
   dp[1] = 1;
 
   // Log initial state before loop
-  l.simple({ n }); // n belongs to 'input' group
+  l.simple({ n: p }); // n belongs to 'input' group
   l.array("dp", dp); // dp belongs to 'computation' group
   l.breakpoint(1, "Initialize base cases for dp array");
 
   // Loop through steps
-  for (let i = 2; i <= n; i++) {
+  for (let i = 2; i <= p; i++) {
     dp[i] = dp[i - 1] + dp[i - 2];
 
     // Log state within the loop
-    l.simple({ n });
+    l.simple({ n: p });
     l.array("dp", dp, i, i - 1, i - 2);
-    l.group("loop", { i }, { min: 2, max: n }); // i belongs to 'computation' group
+    l.group("loop", { i }, { min: 2, max: p }); // i belongs to 'computation' group
     l.breakpoint(2, `Calculate ways for step ${i}`);
     l.hide("loop")
   }
 
   // Log final result
-  const result = dp[n];
-  l.array("dp", dp, n);
+  const result = dp[p];
+  l.array("dp", dp, p);
   l.simple({ result }) // result belongs to 'computation' group
   l.breakpoint(3, "Store the final result");
 


### PR DESCRIPTION
The generateSteps function expected an object with property 'n' but received a number input directly. This caused destructuring `const { n } = p` to result in `n` being undefined. Consequently, `new Array(n + 1)` evaluated to `new Array(NaN)`, throwing a RangeError.

This commit fixes the issue by:
- Removing the incorrect destructuring `const { n } = p;`.
- Using the input parameter `p` directly where `n` was previously used, specifically for array initialization (`new Array(p + 1)`) and loop bounds.