### PR TITLE
fix(houseRobber): Rename exported variable to 'variables'

### DIFF
--- a/packages/backend/src/problem/free/houseRobber/variables.ts
+++ b/packages/backend/src/problem/free/houseRobber/variables.ts
@@ -1,6 +1,6 @@
 import { VariableMetadata } from "algo-lens-core"; // Corrected import
 
-export const variableMetadata: VariableMetadata[] = [ // Changed to array
+export const variables: VariableMetadata[] = [ // Changed to array
   {
     name: "nums", // Key became name
     label: "nums", // Label added (same as name)


### PR DESCRIPTION
Renamed the exported constant in packages/backend/src/problem/free/houseRobber/variables.ts from 'variableMetadata' to 'variables'.

This aligns the naming convention with other problems like '3sum' and resolves the import error encountered during testing.