### PR TITLE
feat: Rename isNodeSame to isNodeSameVariableTemplate

### DIFF
--- a/packages/backend/src/problem/free/sameTree/variables.ts
+++ b/packages/backend/src/problem/free/sameTree/variables.ts
@@ -14,7 +14,7 @@ const qTree = {
   highlight: [],
 };
 
-const isNodeSame = {
+const isNodeSameVariableTemplate = {
   label: "is node same?",
   type: "boolean-group",
   data: [{ label: "return", value: false }],
@@ -34,7 +34,7 @@ export const variables: Variable[] = [
     emoji: "🌳",
   },
   {
-    ...isNodeSame,
+    ...isNodeSameVariableTemplate,
     name: "is node same?",
     description: "Placeholder description for isNodeSame",
     emoji: "❓",


### PR DESCRIPTION
Renamed the constant `isNodeSame` to `isNodeSameVariableTemplate` in `packages/backend/src/problem/free/sameTree/variables.ts` to avoid potential import resolution conflicts with the `isNodeSame` function. Updated its usage within the same file.