### PR TITLE
fix(houseRobber): Initialize options for dpCalculation group

### DIFF
--- a/packages/backend/src/problem/free/houseRobber/steps.ts
+++ b/packages/backend/src/problem/free/houseRobber/steps.ts
@@ -43,6 +43,7 @@ export function generateSteps(nums: number[]) {
     );
     l.array("nums", nums, i - 1); // Highlight current house
     l.array("dp", dp, i, i - 1, i - 2); // Highlight relevant dp values
+    l.groupOptions.set(dpCalculationGroup, { min: 0 }); // Assuming min: 0 is a reasonable default. Adjust if context suggests otherwise.
     l.group(dpCalculationGroup, {
       // Use defined group name
       skipCurrent,


### PR DESCRIPTION
The tests for the houseRobber problem were failing with the error "no options for this group: dpCalculation". This occurred because the StepLoggerV2's `group` method was called for `dpCalculation` without prior options initialization.

This commit fixes the issue by adding `l.groupOptions.set(dpCalculationGroup, { min: 0 });` before the `l.group(dpCalculationGroup, ...)` call within the `generateSteps` function in `src/problem/free/houseRobber/steps.ts`.

Verification via automated testing was not possible due to environment limitations.