### PR TITLE
fix(same-tree): Add missing 'result' variable to final state

### DIFF
--- a/packages/backend/src/problem/free/sameTree/steps.ts
+++ b/packages/backend/src/problem/free/sameTree/steps.ts
@@ -40,7 +40,22 @@ export function sameTree(
   }
 
   // Call the core logic function, passing the log function for step recording
-  isSameTree(p, q, log); // Pass log function to isSameTree
+  const result = isSameTree(p, q, log); // Pass log function to isSameTree
+
+  // Create the result variable
+  const resultVariable: Variable = {
+    label: "result",
+    type: "boolean",
+    value: result,
+  };
+
+  // Add the result variable to the last step or create a new step
+  if (steps.length > 0) {
+    steps[steps.length - 1].variables.push(resultVariable);
+  } else {
+    // If steps is empty (e.g., both trees are initially null), create a new step
+    steps.push({ variables: [resultVariable], breakpoint: 0 }); // Use breakpoint 0 or decide on a suitable value
+  }
 
   return steps;
 }

--- a/packages/backend/src/problem/free/sameTree/variables.ts
+++ b/packages/backend/src/problem/free/sameTree/variables.ts
@@ -39,4 +39,11 @@ export const variables: VariableMetadata[] = [
     description: "Placeholder description for isNodeSame",
     emoji: "❓",
   },
+  {
+    name: "result",
+    label: "result",
+    type: "boolean",
+    description: "The final result of the tree comparison",
+    emoji: "🏁",
+  },
 ];


### PR DESCRIPTION
The 'sameTree' problem visualization was failing tests because the final state generated by the 'steps.ts' function did not include a variable named 'result' holding the overall outcome of the tree comparison.

This commit modifies the `sameTree` function in `steps.ts` to explicitly capture the final boolean result from the `isSameTree` logic and add it as a 'result' variable to the last state pushed to the steps array.

Additionally, metadata for this new 'result' variable has been added to `variables.ts` for clarity in the visualization.