### PR TITLE
feat(backend): add test cases for number-of-islands

### DIFF
--- a/packages/backend/src/problem/free/number-of-islands/testcase.ts
+++ b/packages/backend/src/problem/free/number-of-islands/testcase.ts
@@ -3,4 +3,42 @@
 import { ProblemState, TestCase } from "algo-lens-core";
 import { NumIslandsInput } from "./types";
 
-export const testcases: TestCase<NumIslandsInput, ProblemState>[] = [];
+export const testcases: TestCase<NumIslandsInput, ProblemState>[] = [
+  {
+    input: [],
+    expected: 0,
+    description: "Empty grid",
+  },
+  {
+    input: [
+      ["0", "0", "0"],
+      ["0", "0", "0"],
+    ],
+    expected: 0,
+    description: "Grid with no islands",
+  },
+  {
+    input: [["1"]],
+    expected: 1,
+    description: "Single island",
+  },
+  {
+    input: [
+      ["1", "0", "0"],
+      ["0", "0", "0"],
+      ["0", "0", "1"],
+    ],
+    expected: 2,
+    description: "Multiple separate islands",
+  },
+  {
+    input: [
+      ["1", "1", "0", "0", "0"],
+      ["1", "1", "0", "0", "0"],
+      ["0", "0", "1", "0", "0"],
+      ["0", "0", "0", "1", "1"],
+    ],
+    expected: 3,
+    description: "Complex grid with islands touching corners and edges",
+  },
+];


### PR DESCRIPTION
Adds five test cases to the 'number-of-islands' problem to meet the minimum requirement of four test cases.

The added tests cover:
- Empty grid
- Grid with no islands
- Grid with a single island
- Grid with multiple separate islands
- A complex grid with islands touching corners/edges

This resolves the error "Test cases count should be at least 4" previously encountered when running tests for this problem. I was unable to verify the tests, but the code change directly addresses the error.