### PR TITLE
fix(backend): Increase course schedule test cases to meet minimum

### DIFF
--- a/packages/backend/src/problem/free/course-schedule/testcase.ts
+++ b/packages/backend/src/problem/free/course-schedule/testcase.ts
@@ -45,4 +45,19 @@ export const testcases: TestCase<CourseScheduleInput, boolean>[] = [
     description:
       "Test case 3: The prerequisites are correctly represented and all courses can be taken.",
   },
+
+  // Test case 4
+  {
+    input: [
+      4,
+      [
+        [1, 0],
+        [2, 1],
+        [3, 2],
+      ],
+    ],
+    expected: true,
+    description:
+      "Test case 4: Linear dependency chain, all courses can be taken.",
+  },
 ];


### PR DESCRIPTION
Added a fourth test case to `packages/backend/src/problem/free/course-schedule/testcase.ts`.

This resolves the error 'Test cases count should be at least 4' reported by the test runner. The new test case covers a linear dependency scenario.