### PR TITLE
Refactor(sameTree): Use StepLoggerV2 in steps.ts

### DIFF
--- a/packages/backend/src/problem/free/sameTree/code/typescript.ts
+++ b/packages/backend/src/problem/free/sameTree/code/typescript.ts
@@ -6,39 +6,27 @@ import { BinaryTreeNode, HighlightColor, Variable } from "algo-lens-core";
 // Now accepts a 'log' function to record steps for visualization.
 export function isSameTree(
   p: BinaryTreeNode | null,
-  q: BinaryTreeNode | null,
-  log: (
-    point: number,
-    pNode: BinaryTreeNode | null,
-    qNode: BinaryTreeNode | null,
-    result?: boolean
-  ) => void // Added log parameter type
+  q: BinaryTreeNode | null
 ): boolean {
-  log(1, p, q); // Log initial call
 
   if (!p && !q) {
-    log(2, p, q, true); // Log base case: both null
     return true;
   }
   if (!p || !q) {
-    log(3, p, q, false); // Log base case: one null
     return false;
   }
   if (p.val !== q.val) {
-    log(4, p, q, false); // Log values differ
     return false;
   }
 
   // Recursively check left and right subtrees
-  const leftSame = isSameTree(p.left, q.left, log); // Pass log down
+  const leftSame = isSameTree(p.left, q.left);
   // Short-circuit if left is not the same
   if (!leftSame) {
-    log(5, p, q, false); // Log overall result for this node
     return false;
   }
-  const rightSame = isSameTree(p.right, q.right, log); // Pass log down
+  const rightSame = isSameTree(p.right, q.right);
   const result = leftSame && rightSame;
-  log(5, p, q, result); // Log overall result for this node
   return result;
 }
 

--- a/packages/backend/src/problem/free/sameTree/steps.ts
+++ b/packages/backend/src/problem/free/sameTree/steps.ts
@@ -1,46 +1,84 @@
 import {
   HighlightColor,
-  ProblemState,
   BinaryTreeNode,
-  Variable,
+  Variable, // Kept Variable as StepLoggerV2 might implicitly use it via utils
+  ProblemState, // Need ProblemState for the return type
 } from "algo-lens-core";
-import { asBooleanGroup, asTree } from "../../core/utils"; // Import utility functions
-import { SameTreeInput } from "./types"; // Import the input type
-import { isSameTree } from "./code/typescript"; // Import the core logic function
+import { StepLoggerV2 } from "../../core/StepLoggerV2"; // Import StepLoggerV2
+import { SameTreeInput } from "./types"; // Keep input type for context
 
 // The main function that generates the steps for the visualization
 export function sameTree(
   p: BinaryTreeNode | null,
   q: BinaryTreeNode | null
 ): ProblemState[] {
-  const steps: ProblemState[] = [];
+  const l = new StepLoggerV2();
 
-  // Log function to capture state at each breakpoint
-  function log(
-    point: number,
+  function checkNodes(
     pNode: BinaryTreeNode | null,
-    qNode: BinaryTreeNode | null,
-    result?: boolean
-  ) {
-    let color: HighlightColor = "neutral";
-    if (result === true) {
-      color = "good";
+    qNode: BinaryTreeNode | null
+  ): boolean {
+    l.tree("pTree", p, [{ node: pNode, color: "neutral" as HighlightColor }]);
+    l.tree("qTree", q, [{ node: qNode, color: "neutral" as HighlightColor }]);
+    l.breakpoint(1); // Log initial call
+
+    if (!pNode && !qNode) {
+      l.tree("pTree", p, [{ node: pNode, color: "good" as HighlightColor }]);
+      l.tree("qTree", q, [{ node: qNode, color: "good" as HighlightColor }]);
+      l.simple({ "is node same?": true });
+      l.breakpoint(2); // Log base case: both null
+      return true;
     }
-    if (result === false) {
-      color = "bad";
+    if (!pNode || !qNode) {
+      l.tree("pTree", p, [{ node: pNode, color: "bad" as HighlightColor }]);
+      l.tree("qTree", q, [{ node: qNode, color: "bad" as HighlightColor }]);
+      l.simple({ "is node same?": false });
+      l.breakpoint(3); // Log base case: one null
+      return false;
     }
-    const variables: Variable[] = [
-      asTree("pTree", p, [{ node: pNode, color }]), // Use asTree from core/utils
-      asTree("qTree", q, [{ node: qNode, color }]), // Use asTree from core/utils
-    ];
-    if (result !== undefined) {
-      variables.push(asBooleanGroup("is node same?", { return: result })); // Use asBooleanGroup
+    // Highlight current nodes before value comparison
+    l.tree("pTree", p, [{ node: pNode, color: "neutral" as HighlightColor }]);
+    l.tree("qTree", q, [{ node: qNode, color: "neutral" as HighlightColor }]);
+    if (pNode.val !== qNode.val) {
+      l.tree("pTree", p, [{ node: pNode, color: "bad" as HighlightColor }]);
+      l.tree("qTree", q, [{ node: qNode, color: "bad" as HighlightColor }]);
+      l.simple({ "is node same?": false });
+      l.breakpoint(4); // Log values differ
+      return false;
     }
-    steps.push({ variables, breakpoint: point });
+    // Highlight current nodes as matching before recursion
+    l.tree("pTree", p, [{ node: pNode, color: "good" as HighlightColor }]);
+    l.tree("qTree", q, [{ node: qNode, color: "good" as HighlightColor }]);
+    l.simple({ "is node same?": true }); // Log values are same before recursing
+
+
+    // Recursively check left and right subtrees
+    const leftSame = checkNodes(pNode.left, qNode.left);
+    // Short-circuit if left is not the same - log overall result for this node
+    if (!leftSame) {
+      l.tree("pTree", p, [{ node: pNode, color: "bad" as HighlightColor }]);
+      l.tree("qTree", q, [{ node: qNode, color: "bad" as HighlightColor }]);
+      l.simple({ "overall result": false });
+      l.breakpoint(5);
+      return false;
+    }
+    const rightSame = checkNodes(pNode.right, qNode.right);
+    const result = leftSame && rightSame;
+
+    // Log overall result for this node
+    l.tree("pTree", p, [
+      { node: pNode, color: (result ? "good" : "bad") as HighlightColor },
+    ]);
+    l.tree("qTree", q, [
+      { node: qNode, color: (result ? "good" : "bad") as HighlightColor },
+    ]);
+    l.simple({ "overall result": result });
+    l.breakpoint(5);
+    return result;
   }
 
-  // Call the core logic function, passing the log function for step recording
-  isSameTree(p, q, log); // Pass log function to isSameTree
+  // Start the recursive checking process
+  checkNodes(p, q);
 
-  return steps;
+  return l.getSteps();
 }


### PR DESCRIPTION
Migrates the step generation logic in `packages/backend/src/problem/free/sameTree/steps.ts` from a custom log callback injected into the core logic to using the shared `StepLoggerV2`.

- Modified `sameTree/code/typescript.ts` to remove the `log` parameter from `isSameTree`.
- Refactored `sameTree/steps.ts` to:
    - Import and instantiate `StepLoggerV2`.
    - Replicate the recursive comparison logic within `steps.ts`.
    - Use `l.tree()`, `l.simple()`, and `l.breakpoint()` to generate steps, matching the original breakpoints.
- This aligns the `sameTree` problem's step generation with the pattern used in other problems like `3sum`.