### PR TITLE
Fix(test): Correct expected value for houseRobber test case

### DIFF
--- a/packages/backend/src/problem/free/houseRobber/testcase.ts
+++ b/packages/backend/src/problem/free/houseRobber/testcase.ts
@@ -6,6 +6,6 @@ export const testcases: TestCase<HouseRobberInput, number>[] = [
   // Existing cases (refactored format)
   { input: [1, 2, 3, 1], expected: 4 }, // 1 + 3 = 4
   { input: [2, 7, 9, 3, 1], expected: 12 }, // 2 + 9 + 1 = 12
-  { input: [1, 2, 3, 5, 6, 7, 10], expected: 18 }, // 1 + 7 + 10 = 18
+  { input: [1, 2, 3, 5, 6, 7, 10], expected: 20 }, // 1 + 3 + 6 + 10 = 20
   { input: [0, 0, 0, 0], expected: 0 }, // All houses are empty
 ];


### PR DESCRIPTION
The test case with input `[1, 2, 3, 5, 6, 7, 10]` had an incorrect expected value of 18. The actual maximum value achievable by robbing non-adjacent houses is 20 (1 + 3 + 6 + 10).

This commit updates the expected value to 20 and corrects the accompanying comment in `testcase.ts`. I was unable to run the tests to confirm the fix, but my analysis of the code indicates the implementation is correct and the test case was the source of the error.