### PR TITLE
fix(problem): Add missing 'result' variable metadata for sameTree

### DIFF
--- a/packages/backend/src/problem/free/sameTree/variables.ts
+++ b/packages/backend/src/problem/free/sameTree/variables.ts
@@ -20,6 +20,12 @@ const isNodeSame = {
   data: [{ label: "return", value: false }],
 };
 
+const RESULT_METADATA = {
+  label: "result",
+  type: "boolean",
+  value: false,
+};
+
 export const variables: VariableMetadata[] = [
   {
     ...pTree,
@@ -38,5 +44,12 @@ export const variables: VariableMetadata[] = [
     name: "is node same?",
     description: "Placeholder description for isNodeSame",
     emoji: "❓",
+  },
+  {
+    ...RESULT_METADATA,
+    name: "Result",
+    description:
+      "The final result of comparing the two trees (true if identical, false otherwise).",
+    emoji: "✅",
   },
 ];


### PR DESCRIPTION
The 'sameTree' problem test was failing because the test runner expected metadata for a variable labeled 'result' in the final step, but this metadata was not defined in `variables.ts`.

This commit adds the necessary metadata definition for the 'result' variable (type: boolean) to `packages/backend/src/problem/free/sameTree/variables.ts`, allowing the test runner to correctly identify and validate the final outcome of the problem execution.