### PR TITLE
fix(course-schedule): Correct expected value for cyclic dependency test

### DIFF
--- a/packages/backend/src/problem/free/course-schedule/testcase.ts
+++ b/packages/backend/src/problem/free/course-schedule/testcase.ts
@@ -13,7 +13,7 @@ export const testcases: TestCase<CourseScheduleInput, boolean>[] = [
         [0, 1],
       ],
     ],
-    expected: true,
+    expected: false,
     description: "Test case 1: The prerequisites are correctly represented.",
   },
 


### PR DESCRIPTION
The first test case for the course schedule problem involved a cyclic dependency (`[[1, 0], [0, 1]]`), making it impossible to complete the schedule. However, the test case incorrectly expected `true`.

The `canFinish` function correctly identified the cycle and returned `false`. This commit updates the expected value in the test case from `true` to `false` to accurately reflect the expected outcome for a cyclic dependency, resolving the test failure.