### PR TITLE
fix(number-of-islands): Ensure result variable is in final state

### DIFF
--- a/packages/backend/src/problem/free/number-of-islands/steps.ts
+++ b/packages/backend/src/problem/free/number-of-islands/steps.ts
@@ -76,6 +76,7 @@ export function generateSteps(grid: string[][]): ProblemState[] {
 
   const result = numIslands;
   l.simple({ result });
+  l.breakpoint();
   return l.getSteps();
 }
 

--- a/packages/backend/src/problem/free/number-of-islands/variables.ts
+++ b/packages/backend/src/problem/free/number-of-islands/variables.ts
@@ -27,4 +27,10 @@ export const variables: VariableMetadata[] = [
 
     emoji: "➡️",
   },
+  {
+    name: "result",
+    label: "result",
+    description: "The final count of islands.",
+    emoji: "🏝️", // Island emoji
+  },
 ];


### PR DESCRIPTION
The tests for number-of-islands were failing because the 'result' variable was not found in the last state returned by the problem function.

This commit addresses the issue by:
1. Adding metadata for the 'result' variable in variables.ts.
2. Confirming that steps.ts logs the 'result' using l.simple().
3. Adding a final l.breakpoint() after logging the result in steps.ts to ensure the state containing 'result' is the last one.

Note: I was unable to run tests to confirm the fix, but the changes directly address the identified cause of the error.