### PR TITLE
feat: Add test cases for longestIncreasingSubsequence

### DIFF
--- a/packages/backend/src/problem/free/longestIncreasingSubsequence/testcase.ts
+++ b/packages/backend/src/problem/free/longestIncreasingSubsequence/testcase.ts
@@ -1,3 +1,19 @@
 import { ProblemState, TestCase } from "algo-lens-core";
 
-export const testcases: TestCase<number, ProblemState> = [];
+export const testcases: TestCase<number[], ProblemState>[] = [
+  {
+    input: [10, 9, 2, 5, 3, 7, 101, 18],
+  },
+  {
+    input: [0, 1, 0, 3, 2, 3],
+  },
+  {
+    input: [1, 2, 3, 4, 5],
+  },
+  {
+    input: [5, 4, 3, 2, 1],
+  },
+  {
+    input: [7],
+  },
+];


### PR DESCRIPTION
Adds five diverse test cases to the `testcases` array in `packages/backend/src/problem/free/longestIncreasingSubsequence/testcase.ts`.

This resolves the error "Test cases count should be at least 4" which occurred because the test case array was previously empty.

The added test cases cover:
- Standard case
- Case with duplicates
- Already sorted array
- Reverse-sorted array
- Single-element array

Also corrects the type definition for `testcases` to `TestCase<number[], ProblemState>[]`.