### PR TITLE
fix(problem): Add missing metadata to merge-intervals problem

### DIFF
--- a/packages/backend/src/problem/free/merge-intervals/problem.ts
+++ b/packages/backend/src/problem/free/merge-intervals/problem.ts
@@ -2,6 +2,8 @@ import { Problem, ProblemState } from "algo-lens-core";
 import { generateSteps } from "./steps"; // Will import the renamed function
 import { code } from "./code/typescript";
 import { MergeIntervalsInput } from "./types"; // Import input type from types.ts
+import { variables } from "./variables";
+import { groups } from "./groups";
 
 const title = "Merge Intervals";
 const getInput = () => ({
@@ -27,5 +29,9 @@ export const problem: Problem<
   code,
   func: generateSteps, // Use the renamed function
   id: "merge-intervals",
-  tags: ["interval"]
+  tags: ["interval"],
+  metadata: {
+    variables,
+    groups,
+  },
 };


### PR DESCRIPTION
The test suite for the merge-intervals problem was failing due to a missing 'metadata' field in the problem definition.

This commit adds the required 'metadata' field to 'packages/backend/src/problem/free/merge-intervals/problem.ts', importing the necessary 'variables' and 'groups' from their respective files. This aligns the structure with other problems and resolves the test error.