### PR TITLE
fix(problem): Add missing metadata to pacific-atlantic-water-flow

### DIFF
--- a/packages/backend/src/problem/free/pacific-atlantic-water-flow/problem.ts
+++ b/packages/backend/src/problem/free/pacific-atlantic-water-flow/problem.ts
@@ -20,7 +20,15 @@ const getInput = () => ({
 export const problem: Problem<PacificAtlanticInput, ProblemState> = {
   title,
   emoji: '🌊',
+  metadata: {
+    title: "Pacific Atlantic Water Flow",
+    description: "Given an m x n matrix of non-negative integers representing the height of each unit cell in a continent, the 'Pacific ocean' touches the left and top edges of the matrix and the 'Atlantic ocean' touches the right and bottom edges. Find the list of grid coordinates where water can flow to both the Pacific and Atlantic oceans.",
+    source: "https://leetcode.com/problems/pacific-atlantic-water-flow/",
+    tags: ["Array", "Depth-First Search", "Breadth-First Search", "Matrix"],
+    difficulty: "Medium",
+    id: "pacific-atlantic-water-flow" // Ensure this matches the existing id
+  },
   code,
   func: generateSteps, // Use the renamed function
-  id: "pacific-atlantic-water-flow",
+  id: "pacific-atlantic-water-flow", // Keep existing id outside metadata
 };


### PR DESCRIPTION
The test suite for the pacific-atlantic-water-flow problem was failing due to a missing `metadata` property in the problem definition (`packages/backend/src/problem/free/pacific-atlantic-water-flow/problem.ts`).

This commit adds the required `metadata` object, including title, description, source, tags, difficulty, and id, resolving the error thrown by the test runner which expects this property.