### PR TITLE
Fix: Correct import error in hamming-weight problem

### DIFF
--- a/packages/backend/src/problem/free/number-of-1-bits/problem.ts
+++ b/packages/backend/src/problem/free/number-of-1-bits/problem.ts
@@ -1,7 +1,7 @@
 import { Problem, ProblemState } from "algo-lens-core";
 import { generateSteps } from "./steps"; // Will import the renamed function
 import { HammingWeightInput } from "./types"; // Import input type from types.ts
-import { variables } from "./variables";
+import { variableMetadata } from "./variables";
 import { groups } from "./groups";
 import { testcases } from "./testcase";
 
@@ -17,7 +17,7 @@ export const problem: Problem<HammingWeightInput, ProblemState> = {
   id: "hamming-weight", // Note: id in original file was hamming-weight, but file is number-of-1-bits. Using original id.
   tags: ["bit manipulation"],
   metadata: {
-    variables,
+    variables: variableMetadata,
     groups,
   },
 };


### PR DESCRIPTION
The file `problem.ts` was trying to import `variables` from `./variables.ts`, but the latter exports `variableMetadata`.

This commit corrects the import statement in `problem.ts` to use the correct export name `variableMetadata` and updates its usage accordingly. This resolves the `SyntaxError` reported in the test file that imports `problem.ts`.