### PR TITLE
fix(problem): Add missing metadata to reverse-linked-list

### DIFF
--- a/packages/backend/src/problem/free/reverse-linked-list/problem.ts
+++ b/packages/backend/src/problem/free/reverse-linked-list/problem.ts
@@ -31,4 +31,9 @@ export const problem: Problem<ReverseListInput, ProblemState> = {
   id: "reverse-list",
   tags: ["linked-list"],
   getInput: getInput, // Add getInput here
+  metadata: {
+    id: "reverse-list",
+    title: title,
+    difficulty: "easy",
+  },
 };


### PR DESCRIPTION
The test suite for the reverse-linked-list problem was failing due to a missing `metadata` property on the problem definition object.

This commit adds the required `metadata` field (including id, title, and difficulty) to `packages/backend/src/problem/free/reverse-linked-list/problem.ts`, resolving the error reported in the test execution (`No metadata found in problem.`).