### PR TITLE
Fix(test): Correct expected value for LIS test case

### DIFF
--- a/packages/backend/src/problem/free/longestIncreasingSubsequence/testcase.ts
+++ b/packages/backend/src/problem/free/longestIncreasingSubsequence/testcase.ts
@@ -8,7 +8,7 @@ export const testcases: TestCase<number[], ProblemState>[] = [
   },
   {
     input: [0, 1, 0, 3, 2, 3],
-    expected: 2,
+    expected: 4,
   },
   {
     input: [1, 2, 3, 4, 5],


### PR DESCRIPTION
The implementation for calculating the length of the Longest Increasing Subsequence was correct. However, the test case with input `[0, 1, 0, 3, 2, 3]` had an incorrect expected value of `2`.

The actual LIS length for this input is `4` (e.g., `[0, 1, 2, 3]`). This commit updates the expected value in the test case to `4` to match the correct output of the algorithm.