### PR TITLE
fix(backend): Add missing groups property to pacific-atlantic metadata

### DIFF
--- a/packages/backend/src/problem/free/pacific-atlantic-water-flow/problem.ts
+++ b/packages/backend/src/problem/free/pacific-atlantic-water-flow/problem.ts
@@ -26,7 +26,8 @@ export const problem: Problem<PacificAtlanticInput, ProblemState> = {
     source: "https://leetcode.com/problems/pacific-atlantic-water-flow/",
     tags: ["Array", "Depth-First Search", "Breadth-First Search", "Matrix"],
     difficulty: "Medium",
-    id: "pacific-atlantic-water-flow" // Ensure this matches the existing id
+    id: "pacific-atlantic-water-flow", // Ensure this matches the existing id
+    groups: []
   },
   code,
   func: generateSteps, // Use the renamed function


### PR DESCRIPTION
The tests expect a `groups` property within the `problem.metadata` object. This property was missing for the 'pacific-atlantic-water-flow' problem, causing the tests to fail with a "No groups found in metadata" error.

This commit adds an empty `groups: []` array to the metadata in `packages/backend/src/problem/free/pacific-atlantic-water-flow/problem.ts` to resolve the error. I couldn't verify the test execution due to environment limitations, but the change directly addresses the identified issue.