### PR TITLE
feat: Add TypeScript compilation check to problem tests

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -11,6 +11,7 @@
   },
   "devDependencies": {
     "@types/bun": "latest",
-    "@types/lodash": "^4.17.16"
+    "@types/lodash": "^4.17.16",
+    "typescript": "^5.0.0"
   }
 }

--- a/packages/backend/src/problem/core/test.ts
+++ b/packages/backend/src/problem/core/test.ts
@@ -1,9 +1,70 @@
+import * as ts from "typescript";
 import { Problem, ProblemState } from "algo-lens-core";
 import { cloneDeep, last } from "lodash";
 import { describe, it, expect } from "bun:test";
+import * as fs from "fs";
+import * as path from "path";
 
 export function runTests(problem: Problem<any, ProblemState>) {
   const { testcases, metadata } = problem;
+
+  // Check for TypeScript compilation errors
+  const tsFilePath = path.join(
+    process.cwd(), // Assuming the test runs from the repo root
+    "packages",
+    "backend",
+    "src",
+    "problem",
+    "free",
+    problem.id,
+    "code",
+    "typescript.ts"
+  );
+
+  if (fs.existsSync(tsFilePath)) {
+    const program = ts.createProgram([tsFilePath], {
+      noEmit: true, // We only want to check for errors, not emit JS
+      target: ts.ScriptTarget.ESNext, // Or your desired target
+      module: ts.ModuleKind.CommonJS, // Or your desired module system
+      strict: true, // Enable strict checks
+    });
+
+    const allDiagnostics = ts
+      .getPreEmitDiagnostics(program)
+      .filter((diag) => diag.category === ts.DiagnosticCategory.Error); // Filter for errors only
+
+    if (allDiagnostics.length > 0) {
+      const errorMessage = allDiagnostics
+        .map((diagnostic) => {
+          if (diagnostic.file) {
+            const { line, character } = ts.getLineAndCharacterOfPosition(
+              diagnostic.file,
+              diagnostic.start!
+            );
+            const message = ts.flattenDiagnosticMessageText(
+              diagnostic.messageText,
+              "\n"
+            );
+            return `TypeScript Error: ${diagnostic.file.fileName} (${line + 1},${
+              character + 1
+            }): ${message}`;
+          } else {
+            return `TypeScript Error: ${ts.flattenDiagnosticMessageText(
+              diagnostic.messageText,
+              "\n"
+            )}`;
+          }
+        })
+        .join("\n");
+      throw new Error(`TypeScript compilation failed:\n${errorMessage}`);
+    }
+  } else {
+    // Optional: Log a warning or throw an error if the file is expected
+    console.warn(
+      `Warning: TypeScript file not found for problem ${problem.id} at ${tsFilePath}`
+    );
+  }
+
 
   //has metadata check
   if (!metadata) {
@@ -36,9 +97,11 @@ export function runTests(problem: Problem<any, ProblemState>) {
     //@ts-expect-error
     const value = result.value ?? result.values;
     expect(value).toEqual(expected);
-    /** 
+    /**
     console.log(
-      `Test case passed: ${JSON.stringify(input)} -> ${JSON.stringify(value)}`
+      `Test case passed: ${JSON.stringify(input)} -> ${JSON.stringify(
+        value
+      )}`
     );
     **/
   }


### PR DESCRIPTION
Modified the core testing logic in `packages/backend/src/problem/core/test.ts` to include a compilation check for the corresponding `code/typescript.ts` file for each problem.

- Added `typescript` as a dev dependency to `packages/backend/package.json`.
- Updated `runTests` in `core/test.ts` to locate and compile the relevant `typescript.ts` file using the TypeScript API.
- Tests will now fail if the `typescript.ts` file contains compilation errors.

Note: I was unable to verify this change by running the tests due to limitations in my execution environment.