### PR TITLE
fix(problem): Add missing 'result' variable for number-of-1-bits

### DIFF
--- a/packages/backend/src/problem/free/number-of-1-bits/variables.ts
+++ b/packages/backend/src/problem/free/number-of-1-bits/variables.ts
@@ -19,4 +19,10 @@ export const variables: VariableMetadata[] = [
     description: "The current value of the number being processed in the loop.",
     emoji: "🔍",
   },
+  {
+    name: "count", // The actual variable name holding the result
+    label: "result", // The label expected by the test framework
+    description: "The final count of set bits.",
+    emoji: "✅",
+  },
 ];


### PR DESCRIPTION
The test framework for the 'number-of-1-bits' (hamming-weight) problem was failing because it expected a variable labeled 'result' in the final execution state, but none was defined.

This change adds the necessary metadata to the variables.ts file, mapping the final 'count' variable to the 'result' label, allowing the test framework to correctly identify the function's output.