### PR TITLE
Fix: Correct id for minimumPathSum problem definition

### DIFF
--- a/packages/backend/src/problem/free/minimumPathSum/problem.ts
+++ b/packages/backend/src/problem/free/minimumPathSum/problem.ts
@@ -16,7 +16,7 @@ export const problem: Problem<MinPathSumInput, ProblemState> = {
   testcases,
   difficulty: "medium",
   func: generateSteps, // Use the renamed function
-  id: "minimum-path-sum",
+  id: "minimumPathSum",
   tags: ["2d dynamic programming"],
   metadata: {
     variables,


### PR DESCRIPTION
The problem ID was incorrectly set to 'minimum-path-sum' (kebab-case) instead of 'minimumPathSum' (camelCase). This caused the test runner in `src/problem/core/test.ts` to fail when constructing the file path to the problem's TypeScript code, as it uses the problem ID to find the correct directory.

This change updates the ID in `packages/backend/src/problem/free/minimumPathSum/problem.ts` to the correct camelCase version, resolving the test failure.