### PR TITLE
Refactor: Use l.arrayV2 instead of l.array/logger.array

### DIFF
--- a/packages/backend/src/problem/free/3sum/steps.ts
+++ b/packages/backend/src/problem/free/3sum/steps.ts
@@ -1,9 +1,9 @@
 import { ProblemState } from "algo-lens-core";
-import { StepLogger } from "../../core/StepLogger"; // Assuming StepLogger is in core
+import { StepLoggerV2 } from "../../core/StepLoggerV2"; // Assuming StepLogger is in core
 import { ThreeSumInput } from "./types";
 // Import group names - adjust if groups.ts exports differently
 import { groups } from "./groups";
-import { StepLoggerV2 } from "../../core/StepLoggerV2";
+// Removed duplicate: import { StepLoggerV2 } from "../../core/StepLoggerV2";
 import _ = require("lodash");
 
 export function generateSteps(nums: number[]): ProblemState[] {
@@ -26,7 +26,7 @@ export function generateSteps(nums: number[]): ProblemState[] {
   const seen = new Set<string>(); // To track unique triplets
 
   // Initial state before sorting
-  l.array("nums", nums);
+  l.arrayV2("nums", nums);
   l.simple({ target });
   l.array2d("result", result);
   l.breakpoint(1, "Initial state before sorting");
@@ -34,19 +34,19 @@ export function generateSteps(nums: number[]): ProblemState[] {
   nums.sort((a, b) => a - b); // Sort the array
 
   // State after sorting
-  l.array("nums", nums);
+  l.arrayV2("nums", nums);
   l.simple({ target });
   l.array2d("result", result);
   l.breakpoint(2, "Array sorted");
 
   for (let i = 0; i < nums.length - 2; i++) {
-    l.array("nums", nums, i);
+    l.arrayV2("nums", nums, i);
     l.simple({ target });
     l.array2d("result", result);
     l.breakpoint(3, `Outer loop: Start iteration with i = ${i}`);
 
     if (i > 0 && nums[i] === nums[i - 1]) {
-      l.array("nums", nums, i);
+      l.arrayV2("nums", nums, i);
       l.simple({ target });
       l.array2d("result", result);
       l.breakpoint(4, `Outer loop: Skip duplicate i = ${i}`);
@@ -57,7 +57,7 @@ export function generateSteps(nums: number[]): ProblemState[] {
     let left = i + 1;
     let right = nums.length - 1;
 
-    l.array("nums", nums, i, left, right);
+    l.arrayV2("nums", nums, i, left, right);
     l.simple({ target });
     l.array2d("result", result);
     l.breakpoint(5, `Inner loop: Initialize left = ${left}, right = ${right}`);
@@ -66,7 +66,7 @@ export function generateSteps(nums: number[]): ProblemState[] {
       const sum = nums[i] + nums[left] + nums[right];
       const triplet = [nums[i], nums[left], nums[right]];
 
-      l.array("nums", nums, i, left, right);
+      l.arrayV2("nums", nums, i, left, right);
       l.simple({ target });
       l.group("triplet", triplet);
       l.simple({ sum });
@@ -79,7 +79,7 @@ export function generateSteps(nums: number[]): ProblemState[] {
       if (sum === target) {
         const tripletKey = triplet.join(",");
 
-        l.array("nums", nums, i, left, right);
+        l.arrayV2("nums", nums, i, left, right);
         l.simple({ target });
         l.group("triplet", triplet);
         l.simple({ sum });
@@ -97,7 +97,7 @@ export function generateSteps(nums: number[]): ProblemState[] {
           seen.add(tripletKey);
           result.push(triplet);
 
-          l.array("nums", nums, i, left, right);
+          l.arrayV2("nums", nums, i, left, right);
           l.simple({ target });
           l.group("triplet", triplet);
           l.simple({ sum });
@@ -115,7 +115,7 @@ export function generateSteps(nums: number[]): ProblemState[] {
           skippedLeft = true;
         }
         if (skippedLeft) {
-          l.array("nums", nums, i, left, right);
+          l.arrayV2("nums", nums, i, left, right);
           l.simple({ target });
           l.group("triplet", triplet);
           l.simple({ sum });
@@ -133,7 +133,7 @@ export function generateSteps(nums: number[]): ProblemState[] {
           skippedRight = true;
         }
         if (skippedRight) {
-          l.array("nums", nums, i, left, right);
+          l.arrayV2("nums", nums, i, left, right);
           l.simple({ target });
           l.group("triplet", triplet);
           l.simple({ sum });
@@ -144,7 +144,7 @@ export function generateSteps(nums: number[]): ProblemState[] {
           );
         }
 
-        l.array("nums", nums, i, left, right);
+        l.arrayV2("nums", nums, i, left, right);
         l.simple({ target });
         l.group("triplet", triplet);
         l.simple({ sum });
@@ -157,7 +157,7 @@ export function generateSteps(nums: number[]): ProblemState[] {
         left++;
         right--;
 
-        l.array("nums", nums, i, left, right);
+        l.arrayV2("nums", nums, i, left, right);
         l.simple({ target });
         l.group("triplet", triplet);
         l.simple({ sum });
@@ -169,7 +169,7 @@ export function generateSteps(nums: number[]): ProblemState[] {
           `Inner loop: Moved pointers, new left = ${left}, new right = ${right}`
         );
       } else if (sum < target) {
-        l.array("nums", nums, i, left, right);
+        l.arrayV2("nums", nums, i, left, right);
         l.simple({ target });
         l.group("triplet", triplet);
         l.simple({ sum });
@@ -182,7 +182,7 @@ export function generateSteps(nums: number[]): ProblemState[] {
       } else {
         // sum > target
 
-        l.array("nums", nums, i, left, right);
+        l.arrayV2("nums", nums, i, left, right);
         l.simple({ target });
         l.group("triplet", triplet);
         l.simple({ sum });
@@ -195,13 +195,13 @@ export function generateSteps(nums: number[]): ProblemState[] {
       }
     }
     // Log state at the end of the inner loop for the current 'i'
-    l.array("nums", nums, i, left, right);
+    l.arrayV2("nums", nums, i, left, right);
     l.simple({ target });
     l.array2d("result", result);
     l.breakpoint(14.5, `Inner loop finished for i = ${i}`); // Added intermediate breakpoint
   }
 
-  l.array("nums", nums);
+  l.arrayV2("nums", nums);
   l.simple({ target });
   l.array2d("result", result);
   l.breakpoint(15, "Finished searching for triplets");

--- a/packages/backend/src/problem/free/bestTimeToBuyAndSellStocks/steps.ts
+++ b/packages/backend/src/problem/free/bestTimeToBuyAndSellStocks/steps.ts
@@ -1,5 +1,5 @@
 import { ProblemState } from "algo-lens-core";
-import { StepLogger } from "../../core/StepLogger";
+// Removed: import { StepLogger } from "../../core/StepLogger";
 import { MaxProfitInput } from "./types";
 import { StepLoggerV2 } from "../../core/StepLoggerV2";
 

--- a/packages/backend/src/problem/free/climbingStairs/steps.ts
+++ b/packages/backend/src/problem/free/climbingStairs/steps.ts
@@ -1,5 +1,5 @@
 import { ProblemState } from "algo-lens-core";
-import { StepLogger } from "../../core/StepLogger"; // Adjusted path
+// Removed: import { StepLogger } from "../../core/StepLogger"; // Adjusted path
 import { ClimbingStairsInput } from "./types";
 import { groups } from "./groups"; // Import groups
 import { StepLoggerV2 } from "../../core/StepLoggerV2";
@@ -14,7 +14,7 @@ export function generateSteps(n: number): ProblemState[] {
 
   // Log initial state before loop
   l.simple({ n }); // n belongs to 'input' group
-  l.array("dp", dp); // dp belongs to 'computation' group
+  l.arrayV2("dp", dp); // dp belongs to 'computation' group
   l.breakpoint(1, "Initialize base cases for dp array");
 
   // Loop through steps
@@ -23,7 +23,7 @@ export function generateSteps(n: number): ProblemState[] {
 
     // Log state within the loop
     l.simple({ n });
-    l.array("dp", dp, i, i - 1, i - 2);
+    l.arrayV2("dp", dp, i, i - 1, i - 2);
     l.group("loop", { i }, { min: 2, max: n }); // i belongs to 'computation' group
     l.breakpoint(2, `Calculate ways for step ${i}`);
     l.hide("loop");
@@ -31,7 +31,7 @@ export function generateSteps(n: number): ProblemState[] {
 
   // Log final result
   const result = dp[n];
-  l.array("dp", dp, n);
+  l.arrayV2("dp", dp, n);
   l.simple({ result }); // result belongs to 'computation' group
   l.breakpoint(3, "Store the final result");
 

--- a/packages/backend/src/problem/free/coinChange/steps.ts
+++ b/packages/backend/src/problem/free/coinChange/steps.ts
@@ -12,8 +12,8 @@ export function generateSteps(coins: number[], target: number): ProblemState[] {
 
   // Log initial state (Breakpoint #1)
   l.simple({ target });
-  l.array("coins", coins);
-  l.array("dp", dp, ...[0]);
+  l.arrayV2("coins", coins);
+  l.arrayV2("dp", dp, ...[0]);
   l.breakpoint(1, "Initialize dp table with base case dp[0] = 0");
 
   // Outer loop: Iterate through coins
@@ -30,8 +30,8 @@ export function generateSteps(coins: number[], target: number): ProblemState[] {
 
       // Log state before update check (Breakpoint #2)
       l.simple({ target });
-      l.array("coins", coins, ...[i]);
-      l.array("dp", dp, ...[amount, left]);
+      l.arrayV2("coins", coins, ...[i]);
+      l.arrayV2("dp", dp, ...[amount, left]);
       // Log loop variables and calculations
       l.simple({ coin: coin }); // Log current coin value
       l.simple({ amount });
@@ -45,8 +45,8 @@ export function generateSteps(coins: number[], target: number): ProblemState[] {
 
         // Log state after update (Breakpoint #3 in original code's comment, corresponds to #3 in logic)
         l.simple({ target });
-        l.array("coins", coins, ...[i]);
-        l.array("dp", dp, ...[amount, left]); // dp[amount] is now updated
+        l.arrayV2("coins", coins, ...[i]);
+        l.arrayV2("dp", dp, ...[amount, left]); // dp[amount] is now updated
         // Log loop variables and calculations again
         l.simple({ coin: coin });
         l.simple({ amount });
@@ -61,8 +61,8 @@ export function generateSteps(coins: number[], target: number): ProblemState[] {
   // Log final result (Breakpoint #4 in original code's comment, corresponds to #3 in original ProblemState logic)
   const result = dp[target] === Infinity ? -1 : dp[target];
   l.simple({ target });
-  l.array("coins", coins, ...[]);
-  l.array("dp", dp, ...[target]); // Highlight final dp[target]
+  l.arrayV2("coins", coins, ...[]);
+  l.arrayV2("dp", dp, ...[target]); // Highlight final dp[target]
   l.simple({ result });
   l.breakpoint(4, "Determine final result from dp[target]"); // Adjusted breakpoint number to match code comment
 

--- a/packages/backend/src/problem/free/container-with-most-water/steps.ts
+++ b/packages/backend/src/problem/free/container-with-most-water/steps.ts
@@ -24,7 +24,7 @@ export function generateSteps(height: number[]): ProblemState[] {
 
   // Helper function to create and log each step's computational state
   function log(point: number, area?: number) {
-    l.array("height", height, left, right);
+    l.arrayV2("height", height, left, right);
     l.simple({ maxArea });
     if (area !== undefined) {
       l.simple({ area });

--- a/packages/backend/src/problem/free/containsDuplicate/steps.ts
+++ b/packages/backend/src/problem/free/containsDuplicate/steps.ts
@@ -1,4 +1,3 @@
-
 import { ProblemState } from "algo-lens-core"; // Keep ProblemState for return type hint
 import { asArray, asHashset } from "../../core/utils"; // Keep utils used by logger internally
 import { StepLoggerV2 } from "../../core/StepLoggerV2";
@@ -9,47 +8,47 @@ import { StepLoggerV2 } from "../../core/StepLoggerV2";
  * @returns An array of ProblemState capturing each step of the computation for visualization.
  */
 export function generateSteps(nums: number[]): ProblemState[] {
-  const logger = new StepLoggerV2();
+  const l = new StepLoggerV2(); // Changed logger to l
   let result = false; // Initialize result to false
   const hashSet: Set<number> = new Set();
 
   // Initial state log before the loop starts
-  logger.array("nums", nums);
-  logger.hashset("hashSet", hashSet, {}); // Initial empty hashset state
-  logger.simple({ result }); // Initial result state
-  logger.breakpoint(1);
+  l.arrayV2("nums", nums); // Changed logger.array to l.arrayV2
+  l.hashset("hashSet", hashSet, {}); // Changed logger to l
+  l.simple({ result }); // Changed logger to l // Initial result state
+  l.breakpoint(1); // Changed logger to l
 
   // Main loop to check for duplicates
   for (let i = 0; i < nums.length; i++) {
     // Log state before checking hashSet
-    logger.array("nums", nums, i);
-    logger.hashset("hashSet", hashSet, { value: nums[i], color: "neutral" }); // Highlight value being checked
-    logger.simple({ result });
-    logger.breakpoint(2);
+    l.arrayV2("nums", nums, i); // Changed logger.array to l.arrayV2
+    l.hashset("hashSet", hashSet, { value: nums[i], color: "neutral" }); // Changed logger to l // Highlight value being checked
+    l.simple({ result }); // Changed logger to l
+    l.breakpoint(2); // Changed logger to l
 
     if (hashSet.has(nums[i])) {
       result = true; // Set result to true if duplicate found
       // Log duplicate found state
-      logger.array("nums", nums, i);
-      logger.hashset("hashSet", hashSet, { value: nums[i], color: "error" }); // Highlight duplicate
-      logger.simple({ result }); // Log final true result
-      logger.breakpoint(3);
-      return logger.getSteps(); // Return early
+      l.arrayV2("nums", nums, i); // Changed logger.array to l.arrayV2
+      l.hashset("hashSet", hashSet, { value: nums[i], color: "error" }); // Changed logger to l // Highlight duplicate
+      l.simple({ result }); // Changed logger to l // Log final true result
+      l.breakpoint(3); // Changed logger to l
+      return l.getSteps(); // Changed logger to l // Return early
     } else {
       hashSet.add(nums[i]);
       // Log state after adding to hashSet
-      logger.array("nums", nums, i);
-      logger.hashset("hashSet", hashSet, { value: nums[i], color: "success" }); // Highlight added value
-      logger.simple({ result });
-      logger.breakpoint(4);
+      l.arrayV2("nums", nums, i); // Changed logger.array to l.arrayV2
+      l.hashset("hashSet", hashSet, { value: nums[i], color: "success" }); // Changed logger to l // Highlight added value
+      l.simple({ result }); // Changed logger to l
+      l.breakpoint(4); // Changed logger to l
     }
   }
 
   // Logs the final state when no duplicate is found
-  logger.array("nums", nums); // Final array state
-  logger.hashset("hashSet", hashSet, {}); // Final hashset state
-  logger.simple({ result }); // Log final false result
-  logger.breakpoint(5);
+  l.arrayV2("nums", nums); // Changed logger.array to l.arrayV2 // Final array state
+  l.hashset("hashSet", hashSet, {}); // Changed logger to l // Final hashset state
+  l.simple({ result }); // Changed logger to l // Log final false result
+  l.breakpoint(5); // Changed logger to l
 
-  return logger.getSteps();
+  return l.getSteps(); // Changed logger to l
 }

--- a/packages/backend/src/problem/free/countingBits/steps.ts
+++ b/packages/backend/src/problem/free/countingBits/steps.ts
@@ -8,7 +8,7 @@ export function generateSteps(n: number): ProblemState[] {
 
   // Initial state log before the loop starts
   l.breakpoint(1, "Initialize result array.");
-  l.array("result", result);
+  l.arrayV2("result", result);
 
   //#1 Start the loop to count the number of 1 bits in each integer from 0 to n
   for (let i = 0; i <= n; i++) {
@@ -16,7 +16,7 @@ export function generateSteps(n: number): ProblemState[] {
     let num = i; // Use a temporary variable for the inner loop
 
     l.breakpoint(2, `Start processing number ${i}. Initialize count to 0.`);
-    l.array("result", result, i - 1); // Highlight previous result entry if exists
+    l.arrayV2("result", result, i - 1); // Highlight previous result entry if exists
     l.group("loop", { i }, { min: 0, max: n });
     l.binary({ num }, { highlightLast: true });
     l.group("count", { count }, { min: 0, max: n }); // Max count can be n's bit length technically, but n is safe upper bound vis-wise
@@ -25,7 +25,7 @@ export function generateSteps(n: number): ProblemState[] {
     //#2 Calculate the number of 1 bits in the current integer
     while (inner_num > 0) {
       l.breakpoint(3, "Check the least significant bit.");
-      l.array("result", result, i - 1);
+      l.arrayV2("result", result, i - 1);
       l.group("loop", { i }, { min: 0, max: n });
       l.binary({ num: inner_num }, { highlightLast: true });
       l.group("count", { count }, { min: 0, max: n });
@@ -34,7 +34,7 @@ export function generateSteps(n: number): ProblemState[] {
       if (inner_num & 1) {
         //#4 If the least significant bit is 1, increment the count
         l.breakpoint(4, "LSB is 1. Increment count.");
-        l.array("result", result, i - 1);
+        l.arrayV2("result", result, i - 1);
         l.group("loop", { i }, { min: 0, max: n });
         l.binary({ num: inner_num }, { highlightLast: true });
         l.group("count", { count }, { min: 0, max: n });
@@ -43,19 +43,19 @@ export function generateSteps(n: number): ProblemState[] {
 
         //#5 Log state after incrementing count
         l.breakpoint(5, "Count incremented.");
-        l.array("result", result, i - 1);
+        l.arrayV2("result", result, i - 1);
         l.group("loop", { i }, { min: 0, max: n });
         l.binary({ num: inner_num }, { highlightLast: true });
         l.group("count", { count }, { min: 0, max: n });
       } else {
         l.breakpoint(4, "LSB is 0. No count increment."); // Add breakpoint for else case
-        l.array("result", result, i - 1);
+        l.arrayV2("result", result, i - 1);
         l.group("loop", { i }, { min: 0, max: n });
         l.binary({ num: inner_num }, { highlightLast: true });
         l.group("count", { count }, { min: 0, max: n });
 
         l.breakpoint(5, "Skipping count increment."); // Add breakpoint for else case
-        l.array("result", result, i - 1);
+        l.arrayV2("result", result, i - 1);
         l.group("loop", { i }, { min: 0, max: n });
         l.binary({ num: inner_num }, { highlightLast: true });
         l.group("count", { count }, { min: 0, max: n });
@@ -64,7 +64,7 @@ export function generateSteps(n: number): ProblemState[] {
       //#6 Shift the number to the right to move to the next bit
       inner_num >>= 1;
       l.breakpoint(6, "Right-shift the number to process next bit.");
-      l.array("result", result, i - 1);
+      l.arrayV2("result", result, i - 1);
       l.group("loop", { i }, { min: 0, max: n });
       l.binary({ num: inner_num }, { highlightLast: true }); // Show shifted number
       l.group("count", { count }, { min: 0, max: n });
@@ -75,7 +75,7 @@ export function generateSteps(n: number): ProblemState[] {
       7,
       `Finished counting bits for ${i}. Storing count ${count} in result[${i}].`
     );
-    l.array("result", result, i - 1); // Show previous state
+    l.arrayV2("result", result, i - 1); // Show previous state
     l.group("loop", { i }, { min: 0, max: n });
     l.binary({ num }, { highlightLast: false }); // Show original 'i' value
     l.group("count", { count }, { min: 0, max: n });
@@ -84,14 +84,14 @@ export function generateSteps(n: number): ProblemState[] {
 
     // Log state after storing result
     l.breakpoint(7, `Stored count ${count} in result[${i}].`); // Re-use breakpoint 7 or use a new one if needed
-    l.array("result", result, i); // Highlight the newly added result
+    l.arrayV2("result", result, i); // Highlight the newly added result
     l.group("loop", { i }, { min: 0, max: n });
     l.binary({ num }, { highlightLast: false });
     l.group("count", { count }, { min: 0, max: n });
   }
   //#8 Log final state
   l.breakpoint(8, "Finished processing all numbers. Returning result.");
-  l.array("result", result); // Show final result array
+  l.arrayV2("result", result); // Show final result array
 
   return l.getSteps();
 }

--- a/packages/backend/src/problem/free/course-schedule/steps.ts
+++ b/packages/backend/src/problem/free/course-schedule/steps.ts
@@ -17,8 +17,8 @@ export function generateSteps(numCourses: number, prerequisites: number[][]) {
   l.simple({ numCourses });
   l.hashmap("prerequisites", from2dArrayToMap(prerequisites));
   l.hashmap("graph", from2dArrayToMap(graph));
-  l.array("inDegree", inDegree);
-  l.array("queue", queue);
+  l.arrayV2("inDegree", inDegree);
+  l.arrayV2("queue", queue);
   l.breakpoint(1);
 
   // Initialize the graph and in-degree array
@@ -30,8 +30,8 @@ export function generateSteps(numCourses: number, prerequisites: number[][]) {
       color: "primary",
     });
     l.hashmap("graph", from2dArrayToMap(graph));
-    l.array("inDegree", inDegree, course); // Highlight inDegree[course] before change
-    l.array("queue", queue);
+    l.arrayV2("inDegree", inDegree, course); // Highlight inDegree[course] before change
+    l.arrayV2("queue", queue);
     l.breakpoint(2);
 
     graph[prereq].push(course);
@@ -44,8 +44,8 @@ export function generateSteps(numCourses: number, prerequisites: number[][]) {
       color: "primary",
     });
     l.hashmap("graph", from2dArrayToMap(graph)); // Graph now updated
-    l.array("inDegree", inDegree, course); // Highlight inDegree[course] after change
-    l.array("queue", queue);
+    l.arrayV2("inDegree", inDegree, course); // Highlight inDegree[course] after change
+    l.arrayV2("queue", queue);
     l.breakpoint(3);
   });
 
@@ -53,8 +53,8 @@ export function generateSteps(numCourses: number, prerequisites: number[][]) {
   l.simple({ numCourses });
   l.hashmap("prerequisites", from2dArrayToMap(prerequisites));
   l.hashmap("graph", from2dArrayToMap(graph));
-  l.array("inDegree", inDegree);
-  l.array("queue", queue);
+  l.arrayV2("inDegree", inDegree);
+  l.arrayV2("queue", queue);
   l.breakpoint(4);
 
   // Add courses with no prerequisites to the queue
@@ -63,8 +63,8 @@ export function generateSteps(numCourses: number, prerequisites: number[][]) {
     l.simple({ numCourses, deg });
     l.hashmap("prerequisites", from2dArrayToMap(prerequisites));
     l.hashmap("graph", from2dArrayToMap(graph));
-    l.array("inDegree", inDegree, index); // Highlight current degree being checked
-    l.array("queue", queue);
+    l.arrayV2("inDegree", inDegree, index); // Highlight current degree being checked
+    l.arrayV2("queue", queue);
     l.breakpoint(5);
 
     if (deg === 0) {
@@ -72,8 +72,8 @@ export function generateSteps(numCourses: number, prerequisites: number[][]) {
       l.simple({ numCourses, deg });
       l.hashmap("prerequisites", from2dArrayToMap(prerequisites));
       l.hashmap("graph", from2dArrayToMap(graph));
-      l.array("inDegree", inDegree, index);
-      l.array("queue", queue);
+      l.arrayV2("inDegree", inDegree, index);
+      l.arrayV2("queue", queue);
       l.breakpoint(6);
       queue.push(index);
       // Note: No log immediately after queue.push as the next iteration or step 7 will show it
@@ -84,8 +84,8 @@ export function generateSteps(numCourses: number, prerequisites: number[][]) {
   l.simple({ numCourses });
   l.hashmap("prerequisites", from2dArrayToMap(prerequisites));
   l.hashmap("graph", from2dArrayToMap(graph));
-  l.array("inDegree", inDegree);
-  l.array("queue", queue); // Queue might be populated now
+  l.arrayV2("inDegree", inDegree);
+  l.arrayV2("queue", queue); // Queue might be populated now
   l.breakpoint(7);
 
   let count = 0;
@@ -95,8 +95,8 @@ export function generateSteps(numCourses: number, prerequisites: number[][]) {
     l.group("courses finished", { count });
     l.hashmap("prerequisites", from2dArrayToMap(prerequisites));
     l.hashmap("graph", from2dArrayToMap(graph));
-    l.array("inDegree", inDegree);
-    l.array("queue", queue);
+    l.arrayV2("inDegree", inDegree);
+    l.arrayV2("queue", queue);
     l.breakpoint(8);
 
     const current = queue.shift()!;
@@ -107,8 +107,8 @@ export function generateSteps(numCourses: number, prerequisites: number[][]) {
     l.group("courses finished", { count });
     l.hashmap("prerequisites", from2dArrayToMap(prerequisites));
     l.hashmap("graph", from2dArrayToMap(graph));
-    l.array("inDegree", inDegree);
-    l.array("queue", queue); // Queue after shift
+    l.arrayV2("inDegree", inDegree);
+    l.arrayV2("queue", queue); // Queue after shift
     l.breakpoint(9);
 
     const neighbors = graph[current];
@@ -123,9 +123,9 @@ export function generateSteps(numCourses: number, prerequisites: number[][]) {
         value: current, // Highlight the current course row in the graph
         color: "primary",
       });
-      l.array("neighbors", neighbors, i); // Log neighbors array, highlight current neighbor
-      l.array("inDegree", inDegree, neighbor); // Highlight neighbor's inDegree before change
-      l.array("queue", queue);
+      l.arrayV2("neighbors", neighbors, i); // Log neighbors array, highlight current neighbor
+      l.arrayV2("inDegree", inDegree, neighbor); // Highlight neighbor's inDegree before change
+      l.arrayV2("queue", queue);
       l.breakpoint(10);
 
       inDegree[neighbor]--;
@@ -138,9 +138,9 @@ export function generateSteps(numCourses: number, prerequisites: number[][]) {
         value: current,
         color: "primary",
       });
-      l.array("neighbors", neighbors, i);
-      l.array("inDegree", inDegree, neighbor); // Highlight neighbor's inDegree after change
-      l.array("queue", queue);
+      l.arrayV2("neighbors", neighbors, i);
+      l.arrayV2("inDegree", inDegree, neighbor); // Highlight neighbor's inDegree after change
+      l.arrayV2("queue", queue);
       l.breakpoint(11);
 
       if (inDegree[neighbor] === 0) {
@@ -152,9 +152,9 @@ export function generateSteps(numCourses: number, prerequisites: number[][]) {
           value: current,
           color: "primary",
         });
-        l.array("neighbors", neighbors, i);
-        l.array("inDegree", inDegree, neighbor);
-        l.array("queue", queue); // Queue before push
+        l.arrayV2("neighbors", neighbors, i);
+        l.arrayV2("inDegree", inDegree, neighbor);
+        l.arrayV2("queue", queue); // Queue before push
         l.breakpoint(12);
         queue.push(neighbor);
         // Note: No log immediately after queue.push, next iteration or step 13 will show it
@@ -166,8 +166,8 @@ export function generateSteps(numCourses: number, prerequisites: number[][]) {
     l.group("courses finished", { count });
     l.hashmap("prerequisites", from2dArrayToMap(prerequisites));
     l.hashmap("graph", from2dArrayToMap(graph));
-    l.array("inDegree", inDegree);
-    l.array("queue", queue); // Queue might have new elements
+    l.arrayV2("inDegree", inDegree);
+    l.arrayV2("queue", queue); // Queue might have new elements
     l.breakpoint(13);
   }
 
@@ -179,8 +179,8 @@ export function generateSteps(numCourses: number, prerequisites: number[][]) {
   l.simple({ result: allCoursesTaken });
   l.hashmap("prerequisites", from2dArrayToMap(prerequisites));
   l.hashmap("graph", from2dArrayToMap(graph));
-  l.array("inDegree", inDegree); // Final state of inDegree
-  l.array("queue", queue); // Queue should be empty if successful
+  l.arrayV2("inDegree", inDegree); // Final state of inDegree
+  l.arrayV2("queue", queue); // Queue should be empty if successful
   l.breakpoint(14);
 
   // Return the collected steps

--- a/packages/backend/src/problem/free/houseRobber/steps.ts
+++ b/packages/backend/src/problem/free/houseRobber/steps.ts
@@ -22,14 +22,14 @@ export function generateSteps(nums: number[]) {
   const dp: number[] = new Array(n + 1).fill(0);
   dp[0] = 0;
 
-  l.array("nums", nums);
-  l.array("dp", dp, 0); // Highlight dp[0]
+  l.arrayV2("nums", nums);
+  l.arrayV2("dp", dp, 0); // Highlight dp[0]
   l.breakpoint(1, "Initialize dp array with base case dp[0]");
 
   dp[1] = nums[0];
 
-  l.array("nums", nums, 0); // Highlight nums[0]
-  l.array("dp", dp, 1); // Highlight dp[1]
+  l.arrayV2("nums", nums, 0); // Highlight nums[0]
+  l.arrayV2("dp", dp, 1); // Highlight dp[1]
   l.breakpoint(2, "Set base case dp[1]");
 
   for (let i = 2; i <= n; i++) {
@@ -39,8 +39,8 @@ export function generateSteps(nums: number[]) {
     const includeCurrent = twoHousesBefore + currentHouse;
     dp[i] = Math.max(skipCurrent, includeCurrent);
 
-    l.array("nums", nums, i - 1); // Highlight current house
-    l.array("dp", dp, i, i - 1, i - 2); // Highlight relevant dp values
+    l.arrayV2("nums", nums, i - 1); // Highlight current house
+    l.arrayV2("dp", dp, i, i - 1, i - 2); // Highlight relevant dp values
     l.groupOptions.set(dpCalculationGroup, { min: 0 }); // Assuming min: 0 is a reasonable default. Adjust if context suggests otherwise.
     l.group(dpCalculationGroup, {
       // Use defined group name
@@ -58,8 +58,8 @@ export function generateSteps(nums: number[]) {
 
   const result = dp[n];
 
-  l.array("nums", nums);
-  l.array("dp", dp, n); // Highlight final result in dp array
+  l.arrayV2("nums", nums);
+  l.arrayV2("dp", dp, n); // Highlight final result in dp array
   l.simple({ result }); // Log result in its group
   l.breakpoint(4, "Final result is dp[n]");
 

--- a/packages/backend/src/problem/free/maximum-subarray/steps.ts
+++ b/packages/backend/src/problem/free/maximum-subarray/steps.ts
@@ -16,7 +16,7 @@ export function generateSteps(nums: number[]): ProblemState[] {
   const loopGroup = groups.find((g) => g.name === "loop")!.name;
 
   // Log initial state (Before loop, corresponds to original log(1))
-  l.array("nums", nums, [], inputGroup);
+  l.arrayV2("nums", nums, [], inputGroup);
   l.simple({ maxEndingHere }, kadaneGroup);
   l.simple({ maxSoFar }, kadaneGroup);
   l.breakpoint(
@@ -29,7 +29,7 @@ export function generateSteps(nums: number[]): ProblemState[] {
     const num = nums[i]; // Current number
 
     // Log state at the beginning of the loop (Corresponds to original log(2, i))
-    l.array("nums", nums, [i], inputGroup); // Highlight current number
+    l.arrayV2("nums", nums, [i], inputGroup); // Highlight current number
     l.simple({ maxEndingHere }, kadaneGroup);
     l.simple({ maxSoFar }, kadaneGroup);
     l.simple({ i }, loopGroup);
@@ -44,7 +44,7 @@ export function generateSteps(nums: number[]): ProblemState[] {
 
     if (startNew > extendSum) {
       // Log state *before* updating maxEndingHere (Corresponds roughly to original log(3, i))
-      l.array("nums", nums, [i], inputGroup);
+      l.arrayV2("nums", nums, [i], inputGroup);
       l.simple({ maxEndingHere }, kadaneGroup);
       l.simple({ maxSoFar }, kadaneGroup);
       l.simple({ i }, loopGroup);
@@ -63,7 +63,7 @@ export function generateSteps(nums: number[]): ProblemState[] {
       maxEndingHere = startNew;
 
       // Log state *after* updating maxEndingHere (Corresponds roughly to original log(4, i))
-      l.array("nums", nums, [i], inputGroup);
+      l.arrayV2("nums", nums, [i], inputGroup);
       l.simple({ maxEndingHere }, kadaneGroup); // Updated
       l.simple({ maxSoFar }, kadaneGroup);
       l.simple({ i }, loopGroup);
@@ -71,7 +71,7 @@ export function generateSteps(nums: number[]): ProblemState[] {
       l.breakpoint(3, `Updated maxEndingHere to ${maxEndingHere}.`); // Reuse breakpoint 3 as per code.ts
     } else {
       // Log state *before* updating maxEndingHere (Corresponds roughly to original log(5, i))
-      l.array("nums", nums, [i], inputGroup);
+      l.arrayV2("nums", nums, [i], inputGroup);
       l.simple({ maxEndingHere }, kadaneGroup);
       l.simple({ maxSoFar }, kadaneGroup);
       l.simple({ i }, loopGroup);
@@ -90,7 +90,7 @@ export function generateSteps(nums: number[]): ProblemState[] {
       maxEndingHere = extendSum;
 
       // Log state *after* updating maxEndingHere (Corresponds roughly to original log(6, i))
-      l.array("nums", nums, [i], inputGroup);
+      l.arrayV2("nums", nums, [i], inputGroup);
       l.simple({ maxEndingHere }, kadaneGroup); // Updated
       l.simple({ maxSoFar }, kadaneGroup);
       l.simple({ i }, loopGroup);
@@ -100,7 +100,7 @@ export function generateSteps(nums: number[]): ProblemState[] {
 
     // Update maxSoFar (Corresponds to original log(7, i) to log(9, i) block)
     // Log state *before* updating maxSoFar
-    l.array("nums", nums, [i], inputGroup);
+    l.arrayV2("nums", nums, [i], inputGroup);
     l.simple({ maxEndingHere }, kadaneGroup);
     l.simple({ maxSoFar }, kadaneGroup);
     l.simple({ i }, loopGroup);
@@ -112,7 +112,7 @@ export function generateSteps(nums: number[]): ProblemState[] {
 
     if (maxEndingHere > maxSoFar) {
       // Log state *before* updating maxSoFar (Corresponds roughly to original log(8, i))
-      l.array("nums", nums, [i], inputGroup);
+      l.arrayV2("nums", nums, [i], inputGroup);
       l.simple({ maxEndingHere }, kadaneGroup);
       l.simple({ maxSoFar }, kadaneGroup);
       l.simple({ i }, loopGroup);
@@ -123,7 +123,7 @@ export function generateSteps(nums: number[]): ProblemState[] {
       maxSoFar = maxEndingHere;
 
       // Log state *after* updating maxSoFar (Corresponds roughly to original log(9, i))
-      l.array("nums", nums, [i], inputGroup);
+      l.arrayV2("nums", nums, [i], inputGroup);
       l.simple({ maxEndingHere }, kadaneGroup);
       l.simple({ maxSoFar }, kadaneGroup); // Updated
       l.simple({ i }, loopGroup);
@@ -131,7 +131,7 @@ export function generateSteps(nums: number[]): ProblemState[] {
       l.breakpoint(5, `Updated maxSoFar to ${maxSoFar}.`); // Reuse breakpoint 5
     } else {
       // Log state if maxSoFar is not updated
-      l.array("nums", nums, [i], inputGroup);
+      l.arrayV2("nums", nums, [i], inputGroup);
       l.simple({ maxEndingHere }, kadaneGroup);
       l.simple({ maxSoFar }, kadaneGroup);
       l.simple({ i }, loopGroup);
@@ -143,7 +143,7 @@ export function generateSteps(nums: number[]): ProblemState[] {
   }
 
   // Final state log (Corresponds to original log(11))
-  l.array("nums", nums, [], inputGroup);
+  l.arrayV2("nums", nums, [], inputGroup);
   l.simple({ maxEndingHere }, kadaneGroup);
   l.simple({ maxSoFar }, kadaneGroup); // Final result
   l.simple({ result: maxSoFar }, kadaneGroup); // Add this line to log 'result'

--- a/packages/backend/src/problem/free/missingNumber/steps.ts
+++ b/packages/backend/src/problem/free/missingNumber/steps.ts
@@ -14,7 +14,7 @@ export function generateSteps(nums: number[]): ProblemState[] {
   let actualSum = 0;
 
   // Breakpoint 1: Initial state
-  l.array("nums", nums); // Log initial array
+  l.arrayV2("nums", nums); // Log initial array
   l.group("sum", { expectedSum, actualSum }); // Log initial sums
 
   l.breakpoint(1);
@@ -23,7 +23,7 @@ export function generateSteps(nums: number[]): ProblemState[] {
     actualSum += nums[i];
 
     // Breakpoint 2: Inside loop state
-    l.array("nums", nums, i); // Log array, highlighting index i
+    l.arrayV2("nums", nums, i); // Log array, highlighting index i
     l.group("sum", { expectedSum, actualSum }); // Log current sums
     l.group("loop", { i }); // Log loop variable i
     l.breakpoint(2);
@@ -33,7 +33,7 @@ export function generateSteps(nums: number[]): ProblemState[] {
   const result = expectedSum - actualSum;
 
   // Breakpoint 3: Final state
-  l.array("nums", nums); // Log final array state
+  l.arrayV2("nums", nums); // Log final array state
   l.group("sum", { expectedSum, actualSum, result }); // Log final sums and result
   // Optionally log result as simple value if not included in 'sum' group
   l.simple({ result });

--- a/packages/backend/src/problem/free/product-of-array-except-self/steps.ts
+++ b/packages/backend/src/problem/free/product-of-array-except-self/steps.ts
@@ -9,7 +9,7 @@ import { StepLoggerV2 } from "../../core/StepLoggerV2";
  * @returns An array of ProblemState capturing each step of the computation for visualization.
  */
 export function generateSteps(nums: number[]): ProblemState[] {
-  const logger = new StepLoggerV2();
+  const l = new StepLoggerV2(); // Changed logger to l
   const length = nums.length;
   const output: number[] = new Array(length).fill(1);
   // Create the left (prefix) and right (suffix) products arrays
@@ -17,49 +17,49 @@ export function generateSteps(nums: number[]): ProblemState[] {
   const productsRight: number[] = new Array(length).fill(1);
 
   // Log the initial state
-  logger.array("nums", nums);
-  logger.array("productsLeft", productsLeft);
-  logger.array("productsRight", productsRight);
-  logger.array("output", output);
-  logger.breakpoint(1);
+  l.arrayV2("nums", nums); // Changed logger.array to l.arrayV2
+  l.arrayV2("productsLeft", productsLeft); // Changed logger.array to l.arrayV2
+  l.arrayV2("productsRight", productsRight); // Changed logger.array to l.arrayV2
+  l.arrayV2("output", output); // Changed logger.array to l.arrayV2
+  l.breakpoint(1); // Changed logger to l
 
   // Fill productsLeft array (prefix products)
   for (let i = 1; i < length; i++) {
     productsLeft[i] = productsLeft[i - 1] * nums[i - 1];
-    logger.array("nums", nums, { pointer: [i - 1] });
-    logger.array("productsLeft", productsLeft, { pointer: [i, i - 1] });
-    logger.array("productsRight", productsRight);
-    logger.array("output", output);
-    logger.breakpoint(2);
+    l.arrayV2("nums", nums, { pointer: [i - 1] }); // Changed logger.array to l.arrayV2
+    l.arrayV2("productsLeft", productsLeft, { pointer: [i, i - 1] }); // Changed logger.array to l.arrayV2
+    l.arrayV2("productsRight", productsRight); // Changed logger.array to l.arrayV2
+    l.arrayV2("output", output); // Changed logger.array to l.arrayV2
+    l.breakpoint(2); // Changed logger to l
   }
 
   // Fill productsRight array (suffix products)
   for (let i = length - 2; i >= 0; i--) {
     productsRight[i] = productsRight[i + 1] * nums[i + 1];
-    logger.array("nums", nums, ...[i + 1]);
-    logger.array("productsLeft", productsLeft);
-    logger.array("productsRight", productsRight, ...[i, i + 1]);
-    logger.array("output", output);
-    logger.breakpoint(3);
+    l.arrayV2("nums", nums, ...[i + 1]); // Changed logger.array to l.arrayV2
+    l.arrayV2("productsLeft", productsLeft); // Changed logger.array to l.arrayV2
+    l.arrayV2("productsRight", productsRight, ...[i, i + 1]); // Changed logger.array to l.arrayV2
+    l.arrayV2("output", output); // Changed logger.array to l.arrayV2
+    l.breakpoint(3); // Changed logger to l
   }
 
   // Calculate the output array by combining prefix and suffix products
   for (let i = 0; i < length; i++) {
     output[i] = productsLeft[i] * productsRight[i];
-    logger.array("nums", nums);
-    logger.array("productsLeft", productsLeft, i);
-    logger.array("productsRight", productsRight, i);
-    logger.array("output", output, i);
-    logger.breakpoint(4);
+    l.arrayV2("nums", nums); // Changed logger.array to l.arrayV2
+    l.arrayV2("productsLeft", productsLeft, i); // Changed logger.array to l.arrayV2
+    l.arrayV2("productsRight", productsRight, i); // Changed logger.array to l.arrayV2
+    l.arrayV2("output", output, i); // Changed logger.array to l.arrayV2
+    l.breakpoint(4); // Changed logger to l
   }
 
   // Log the final state with the result
-  logger.array("result", output);
-  logger.hide("nums");
-  logger.hide("productsLeft");
-  logger.hide("productsRight");
-  logger.hide("output");
-  logger.breakpoint(5);
+  l.arrayV2("result", output); // Changed logger.array to l.arrayV2
+  l.hide("nums"); // Changed logger to l
+  l.hide("productsLeft"); // Changed logger to l
+  l.hide("productsRight"); // Changed logger to l
+  l.hide("output"); // Changed logger to l
+  l.breakpoint(5); // Changed logger to l
 
-  return logger.getSteps();
+  return l.getSteps(); // Changed logger to l
 }

--- a/packages/backend/src/problem/free/search-in-rotated-sorted-array/steps.ts
+++ b/packages/backend/src/problem/free/search-in-rotated-sorted-array/steps.ts
@@ -19,7 +19,7 @@ export function generateSteps(p: SearchInput): ProblemState[] {
   let result = -1;
 
   // Initial state log before the loop starts
-  l.array("nums", nums, { left, right });
+  l.arrayV2("nums", nums, { left, right });
   l.simple("target", target);
   l.simple("result", result);
   l.breakpoint(1);
@@ -28,49 +28,49 @@ export function generateSteps(p: SearchInput): ProblemState[] {
   while (left <= right) {
     const mid = Math.floor((left + right) / 2);
     l.simple("mid", mid);
-    l.array("nums", nums, { left, right, mid });
+    l.arrayV2("nums", nums, { left, right, mid });
     l.breakpoint(2);
 
     if (nums[mid] === target) {
       result = mid;
       l.simple("result", result);
-      l.array("nums", nums, { left, right, mid });
+      l.arrayV2("nums", nums, { left, right, mid });
       l.breakpoint(3);
       return l.getSteps();
     }
 
     if (nums[left] <= nums[mid]) {
-      l.array("nums", nums, { left, right, mid });
+      l.arrayV2("nums", nums, { left, right, mid });
       l.breakpoint(4);
       //Check if the left half is sorted
       if (nums[left] <= target && target < nums[mid]) {
         //#5 If the target is in the left half, move the right pointer
         right = mid - 1;
         l.simple("right", right);
-        l.array("nums", nums, { left, right });
+        l.arrayV2("nums", nums, { left, right });
         l.breakpoint(5);
       } else {
         //#6 If the target is not in the left half, move the left pointer
         left = mid + 1;
         l.simple("left", left);
-        l.array("nums", nums, { left, right });
+        l.arrayV2("nums", nums, { left, right });
         l.breakpoint(6);
       }
     } else {
-      l.array("nums", nums, { left, right, mid });
+      l.arrayV2("nums", nums, { left, right, mid });
       l.breakpoint(7);
       //#7 Check if the right half is sorted
       if (nums[mid] < target && target <= nums[right]) {
         //#8 If the target is in the right half, move the left pointer
         left = mid + 1;
         l.simple("left", left);
-        l.array("nums", nums, { left, right });
+        l.arrayV2("nums", nums, { left, right });
         l.breakpoint(8);
       } else {
         //#9 If the target is not in the right half, move the right pointer
         right = mid - 1;
         l.simple("right", right);
-        l.array("nums", nums, { left, right });
+        l.arrayV2("nums", nums, { left, right });
         l.breakpoint(9);
       }
     }
@@ -81,7 +81,7 @@ export function generateSteps(p: SearchInput): ProblemState[] {
   // Logs the final state if the target is not found
   result = -1; // Explicitly set result to -1 if loop finishes without finding target
   l.simple("result", result);
-  l.array("nums", nums, { left, right });
+  l.arrayV2("nums", nums, { left, right });
   l.breakpoint(10);
 
   return l.getSteps();

--- a/packages/backend/src/problem/free/two-sum/steps.ts
+++ b/packages/backend/src/problem/free/two-sum/steps.ts
@@ -8,7 +8,7 @@ export function generateSteps(nums: number[], target: number): ProblemState[] {
   const seen = new Map<number, number>();
 
   l.simple("target", target);
-  l.array("nums", nums);
+  l.arrayV2("nums", nums);
   l.hashmap("seen", seen);
   l.breakpoint(1); // Corresponds to #1 in original code
 
@@ -17,7 +17,7 @@ export function generateSteps(nums: number[], target: number): ProblemState[] {
     const complement = target - num;
 
     // Highlight current element and show complement needed
-    l.array("nums", nums, { [i]: "primary" });
+    l.arrayV2("nums", nums, { [i]: "primary" });
     l.simple("complement", complement);
     l.breakpoint(2); // Corresponds to #2
 
@@ -32,9 +32,9 @@ export function generateSteps(nums: number[], target: number): ProblemState[] {
 
     if (existsInSet) {
       // Highlight the found pair in nums array
-      l.array("nums", nums, { [i]: "success", [complementIndex]: "success" });
+      l.arrayV2("nums", nums, { [i]: "success", [complementIndex]: "success" });
       // Show the final result
-      l.array("result", [complementIndex, i]);
+      l.arrayV2("result", [complementIndex, i]);
       l.breakpoint(3); // Corresponds to #3
       return l.getSteps();
     }
@@ -45,7 +45,7 @@ export function generateSteps(nums: number[], target: number): ProblemState[] {
     // No explicit breakpoint 4 in the original structure, but logging the map update is useful
   }
 
-  l.array("result", []); // No solution found
+  l.arrayV2("result", []); // No solution found
 
   // Original code didn't have a specific step for not found,
   // but we can add one if needed, mirroring the original return pattern.


### PR DESCRIPTION
I iterated through all problem files in `packages/backend/src/problem/free/`.

I updated files using `StepLogger` or `StepLoggerV2` to consistently use `l.arrayV2` instead of the older `l.array` or `logger.array` methods.

I also standardized the logger import to `StepLoggerV2` and the variable instantiation to `const l = new StepLoggerV2();`.

I skipped files using older manual step generation methods or incompatible logger patterns.