### PR TITLE
fix: Align problem IDs with LeetCode numerical IDs

### DIFF
--- a/packages/backend/src/problem/free/3sum/problem.ts
+++ b/packages/backend/src/problem/free/3sum/problem.ts
@@ -11,7 +11,7 @@ export const problem: Problem<ThreeSumInput, ProblemState> = {
   func: generateSteps,
   testcases: testcases,
   difficulty: "medium",
-  id: "3sum",
+  id: "15",
   tags: ["array", "hash set", "two pointers"],
   metadata: {
     variables,

--- a/packages/backend/src/problem/free/bestTimeToBuyAndSellStocks/problem.ts
+++ b/packages/backend/src/problem/free/bestTimeToBuyAndSellStocks/problem.ts
@@ -11,7 +11,7 @@ export const problem: Problem<MaxProfitInput, ProblemState> = {
   title: title,
   emoji: "📈",
   func: generateSteps,
-  id: "bestTimeToBuyAndSellStocks",
+  id: "121",
   testcases,
   tags: ["array"],
   metadata: {

--- a/packages/backend/src/problem/free/climbingStairs/problem.ts
+++ b/packages/backend/src/problem/free/climbingStairs/problem.ts
@@ -12,7 +12,7 @@ export const problem: Problem<ClimbingStairsInput, ProblemState> = {
   emoji: "🪜",
   func: generateSteps, // Use generateSteps from steps.ts
   testcases,
-  id: "climbingStairs",
+  id: "70",
   tags: ["dynamic programming"],
   difficulty: "easy",
   metadata: {

--- a/packages/backend/src/problem/free/coinChange/problem.ts
+++ b/packages/backend/src/problem/free/coinChange/problem.ts
@@ -13,7 +13,7 @@ export const problem: Problem<CoinChangeInput, ProblemState> = {
   func: (input) => generateSteps(...input),
   difficulty: "medium",
   testcases,
-  id: "coinChange",
+  id: "322",
   tags: ["dynamic programming", "array"],
   metadata: {
     variables,

--- a/packages/backend/src/problem/free/container-with-most-water/problem.ts
+++ b/packages/backend/src/problem/free/container-with-most-water/problem.ts
@@ -12,7 +12,7 @@ export const problem: Problem<ContainerInput, ProblemState> = {
   testcases,
   difficulty: "easy",
   func: generateSteps, // Use the renamed function
-  id: "container-with-most-water",
+  id: "11",
   tags: ["array", "two pointers"],
   metadata: {
     variables,

--- a/packages/backend/src/problem/free/containsDuplicate/problem.ts
+++ b/packages/backend/src/problem/free/containsDuplicate/problem.ts
@@ -14,7 +14,7 @@ export const problem: Problem<ContainsDuplicateInput, ProblemState> = {
   emoji: "👯",
   func: generateSteps, // Use local function
   testcases,
-  id: "contains-duplicate", // Keep original ID for now, might need adjustment later
+  id: "217", // Keep original ID for now, might need adjustment later
   tags: ["hashset"],
   difficulty: "medium",
   metadata: {

--- a/packages/backend/src/problem/free/countingBits/problem.ts
+++ b/packages/backend/src/problem/free/countingBits/problem.ts
@@ -12,7 +12,7 @@ export const problem: Problem<CountBitsInput, ProblemState> = {
   emoji: "🧮",
   func: generateSteps,
   testcases,
-  id: "countingBits",
+  id: "338",
   tags: ["dynamic programming", "bit manipulation"],
   difficulty: "easy",
   metadata: {

--- a/packages/backend/src/problem/free/course-schedule/problem.ts
+++ b/packages/backend/src/problem/free/course-schedule/problem.ts
@@ -14,7 +14,7 @@ export const problem: Problem<CourseScheduleInput, ProblemState> = {
   difficulty: "medium",
   func: (i) => generateSteps(...i),
   testcases,
-  id: "course-schedule",
+  id: "207",
   tags: ["graph", "topological sort", "dfs", "bfs"],
   metadata: {
     variables,

--- a/packages/backend/src/problem/free/editDistance/problem.ts
+++ b/packages/backend/src/problem/free/editDistance/problem.ts
@@ -10,7 +10,7 @@ const title = "Edit Distance";
 export const problem: Problem<EditDistanceInput, ProblemState> = {
   title,
   emoji: "✍️", // Updated emoji
-  id: "editDistance", // Updated id
+  id: "72", // Updated id
   tags: ["dynamic programming", "string"],
   func: (input) => generateSteps(...input), // Corrected function assignment
   testcases, // Added testcases property

--- a/packages/backend/src/problem/free/houseRobber/problem.ts
+++ b/packages/backend/src/problem/free/houseRobber/problem.ts
@@ -13,7 +13,7 @@ export const problem: Problem<HouseRobberInput, ProblemState> = {
   func: generateSteps, // Use imported generateSteps function
   difficulty: "medium",
   testcases, // Added testcases
-  id: "houseRobber", // Updated id
+  id: "198", // Updated id
   tags: ["dynamic programming", "array"], // Updated tags
   metadata: {
     // Add metadata

--- a/packages/backend/src/problem/free/insert-interval/problem.ts
+++ b/packages/backend/src/problem/free/insert-interval/problem.ts
@@ -13,7 +13,7 @@ export const problem: Problem<InsertIntervalInput, ProblemState> = {
   func: (i) => generateSteps(...i), // Use generateSteps from steps.ts
   testcases,
   difficulty: "medium",
-  id: "insert-interval",
+  id: "57",
   tags: ["array", "intervals"], // Updated tags
   metadata: {
     variables,

--- a/packages/backend/src/problem/free/longestIncreasingSubsequence/problem.ts
+++ b/packages/backend/src/problem/free/longestIncreasingSubsequence/problem.ts
@@ -12,7 +12,7 @@ export const problem: Problem<LISInput, ProblemState> = {
   emoji: "📈",
   func: generateSteps,
   testcases,
-  id: "longestIncreasingSubsequence",
+  id: "300",
   difficulty: "easy",
   tags: ["dynamic programming", "array", "binary search"],
   metadata: {

--- a/packages/backend/src/problem/free/maximum-subarray/problem.ts
+++ b/packages/backend/src/problem/free/maximum-subarray/problem.ts
@@ -13,7 +13,7 @@ export const problem: Problem<MaximumSubarrayInput, ProblemState> = {
   func: generateSteps, // Use generateSteps from steps.ts
   testcases, // Added testcases
   difficulty: "medium", // Updated difficulty level
-  id: "maximum-subarray",
+  id: "53",
   tags: ["dynamic programming", "array", "divide and conquer"], // Updated tags
   metadata: {
     variables: variableMetadata, // Updated usage

--- a/packages/backend/src/problem/free/merge-intervals/problem.ts
+++ b/packages/backend/src/problem/free/merge-intervals/problem.ts
@@ -12,7 +12,7 @@ export const problem: Problem<MergeIntervalsInput, ProblemState> = {
   testcases,
   difficulty: "medium",
   func: generateSteps, // Use the renamed function
-  id: "merge-intervals",
+  id: "56",
   tags: ["interval"],
   metadata: {
     variables,

--- a/packages/backend/src/problem/free/minimumPathSum/problem.ts
+++ b/packages/backend/src/problem/free/minimumPathSum/problem.ts
@@ -16,7 +16,7 @@ export const problem: Problem<MinPathSumInput, ProblemState> = {
   testcases,
   difficulty: "medium",
   func: generateSteps, // Use the renamed function
-  id: "minimumPathSum",
+  id: "64",
   tags: ["2d dynamic programming"],
   metadata: {
     variables,

--- a/packages/backend/src/problem/free/missingNumber/problem.ts
+++ b/packages/backend/src/problem/free/missingNumber/problem.ts
@@ -12,7 +12,7 @@ const title = "Missing Number";
 export const problem: Problem<MissingNumberInput, ProblemState> = {
   title,
   emoji: "❓",
-  id: "missing-number",
+  id: "268",
   tags: ["math", "array"],
   func: generateSteps, // Imported from ./steps
   testcases,

--- a/packages/backend/src/problem/free/non-overlapping-intervals/problem.ts
+++ b/packages/backend/src/problem/free/non-overlapping-intervals/problem.ts
@@ -12,7 +12,7 @@ export const problem: Problem<EraseOverlapIntervalsInput, ProblemState> = {
   title,
   emoji: "✂️",
   func: generateSteps,
-  id: "non-overlapping-intervals",
+  id: "435",
   tags: ["interval"],
   metadata: {
     variables,

--- a/packages/backend/src/problem/free/number-of-1-bits/problem.ts
+++ b/packages/backend/src/problem/free/number-of-1-bits/problem.ts
@@ -14,7 +14,7 @@ export const problem: Problem<HammingWeightInput, ProblemState> = {
   testcases,
   difficulty: "easy",
   func: generateSteps, // Use the renamed function
-  id: "hamming-weight", // Note: id in original file was hamming-weight, but file is number-of-1-bits. Using original id.
+  id: "191", // Note: id in original file was hamming-weight, but file is number-of-1-bits. Using original id.
   tags: ["bit manipulation"],
   metadata: {
     variables,

--- a/packages/backend/src/problem/free/number-of-islands/problem.ts
+++ b/packages/backend/src/problem/free/number-of-islands/problem.ts
@@ -12,7 +12,7 @@ export const problem: Problem<NumIslandsInput, ProblemState> = {
   title: "Number of Islands",
   emoji: "🏝️",
   func: generateSteps, // Use the renamed function
-  id: "number-of-islands",
+  id: "200",
   difficulty: "medium",
   tags: ["graph"],
   metadata: { variables, groups },

--- a/packages/backend/src/problem/free/pacific-atlantic-water-flow/problem.ts
+++ b/packages/backend/src/problem/free/pacific-atlantic-water-flow/problem.ts
@@ -21,5 +21,5 @@ export const problem: Problem<PacificAtlanticInput, ProblemState> = {
   testcases,
   difficulty: "medium",
   func: generateSteps, // Use the renamed function
-  id: "pacific-atlantic-water-flow", // Keep existing id outside metadata
+  id: "417", // Keep existing id outside metadata
 };

--- a/packages/backend/src/problem/free/product-of-array-except-self/problem.ts
+++ b/packages/backend/src/problem/free/product-of-array-except-self/problem.ts
@@ -8,7 +8,7 @@ import { testcases } from "./testcase";
 
 const title = "Product of Array Except Self";
 const emoji = "✖️";
-const id = "product-of-array-except-self";
+const id = "238";
 const tags = ["array", "prefix sum"];
 
 export const problem: Problem<ProductExceptSelfInput, ProblemState> = {

--- a/packages/backend/src/problem/free/reverse-linked-list/problem.ts
+++ b/packages/backend/src/problem/free/reverse-linked-list/problem.ts
@@ -12,7 +12,7 @@ export const problem: Problem<ReverseListInput, ProblemState> = {
   title,
   emoji: "↩️",
   func: reverseList,
-  id: "reverse-list",
+  id: "206",
   tags: ["linked-list"],
   difficulty: "medium",
   metadata: {

--- a/packages/backend/src/problem/free/sameTree/problem.ts
+++ b/packages/backend/src/problem/free/sameTree/problem.ts
@@ -12,7 +12,7 @@ export const problem: Problem<SameTreeInput, ProblemState> = {
   emoji: "🌲",
   func: (i) => sameTree(...i), // This function generates the steps
   testcases,
-  id: "same-tree",
+  id: "100",
   difficulty: "easy",
   tags: ["tree"],
   metadata: {

--- a/packages/backend/src/problem/free/search-in-rotated-sorted-array/problem.ts
+++ b/packages/backend/src/problem/free/search-in-rotated-sorted-array/problem.ts
@@ -11,7 +11,7 @@ export const problem: Problem<SearchInput, ProblemState> = {
   title: "Search in Rotated Sorted Array",
   emoji: '🔍',
   func: generateSteps, // Use the step generation function
-  id: "search-in-rotated-sorted-array",
+  id: "33",
   tags: ["array", "binary-search"],
   testcases, // Use the imported test cases
   metadata: {

--- a/packages/backend/src/problem/free/set-matrix-zeros/problem.ts
+++ b/packages/backend/src/problem/free/set-matrix-zeros/problem.ts
@@ -13,7 +13,7 @@ export const problem: Problem<SetMatrixZeroesInput, ProblemState> = {
   emoji: "0️⃣", // Keep the emoji from the original file
   func: generateSteps,
   testcases: testcases,
-  id: "set-matrix-zeroes", // Keep the id from the original file
+  id: "73", // Keep the id from the original file
   tags: ["matrix"], // Keep the tags from the original file
   difficulty: "medium", // Keep the difficulty from the original file
   metadata: {

--- a/packages/backend/src/problem/free/sum-of-two-integers.ts
+++ b/packages/backend/src/problem/free/sum-of-two-integers.ts
@@ -115,6 +115,6 @@ export const problem: Problem<SumOfTwoIntegersInput, number> = {
   emoji: '➕',
   code,
   func: sumOfTwoIntegers,
-  id: "sum-of-two-integers",
+  id: "371",
   tags: ["bit manipulation"],
 };

--- a/packages/backend/src/problem/free/two-sum/problem.ts
+++ b/packages/backend/src/problem/free/two-sum/problem.ts
@@ -9,7 +9,7 @@ export const problem: Problem<TwoSumInput, ProblemState> = {
   title: "Two Sum",
   emoji: "🎯",
   func: (i) => generateSteps(...i), // Use the imported step generation function
-  id: "two-sum",
+  id: "1",
   difficulty: "easy",
   tags: ["array", "hash set"],
   metadata: {

--- a/packages/backend/src/problem/free/unique-paths/problem.ts
+++ b/packages/backend/src/problem/free/unique-paths/problem.ts
@@ -9,7 +9,7 @@ import { testcases } from "./testcase";   // Import actual testcases
 export const problem: Problem<UniquePathsInput, ProblemState> = { // Using ProblemState as the second generic type as generateSteps returns ProblemState[]
   title: "Unique Paths",
   emoji: '🤖',
-  id: "unique-paths",
+  id: "62",
   tags: ["2d dynamic programming"],
   func: generateSteps,
   testcases: testcases, // Use imported testcases

--- a/packages/backend/src/problem/free/wordBreak/problem.ts
+++ b/packages/backend/src/problem/free/wordBreak/problem.ts
@@ -16,7 +16,7 @@ export const problem: Problem<WordBreakInput, WordBreakProblemState> = {
   emoji: '📖',
   code: code, // Import from code/solution.ts
   func: wordBreak, // Import from code/index.ts
-  id: "word-break",
+  id: "139",
   tags: ["dynamic programming", "string"],
   getInput: getInput, // Add the getInput function here
 };


### PR DESCRIPTION
Updates the `id` field within the `problem.ts` file for each problem in `packages/backend/src/problem/free/` to match the corresponding official LeetCode numerical ID.

For example, the problem defined in `two-sum/problem.ts` now has `id: "1"`.

Also updates the ID for the problem defined in `sum-of-two-integers.ts` to `id: "371"`.

Note: Folder renaming to match LeetCode slugs and moving the `sum-of-two-integers` files into a dedicated folder were skipped as I encountered difficulties with file and folder path resolution during the renaming and moving process.