### PR TITLE
feat: Add test cases for non-overlapping-intervals

### DIFF
--- a/packages/backend/src/problem/free/non-overlapping-intervals/testcase.ts
+++ b/packages/backend/src/problem/free/non-overlapping-intervals/testcase.ts
@@ -1,1 +1,17 @@
-export const testcases = [];
+import { TestCase } from 'algo-lens-core'; // Assuming TestCase type exists and path is correct
+import { EraseOverlapIntervalsInput } from './types'; // Assuming types file exists here
+
+export const testcases: TestCase<EraseOverlapIntervalsInput, number>[] = [
+  // Basic overlap combined with touching intervals
+  { input: { intervals: [[1,2], [2,3], [3,4], [1,3]] }, output: 1 },
+  // No overlap
+  { input: { intervals: [[1,2], [3,4], [5,6]] }, output: 0 },
+  // Edge case: Empty input array
+  { input: { intervals: [] }, output: 0 },
+  // Edge case: Single interval
+  { input: { intervals: [[1,10]] }, output: 0 },
+  // More complex overlap scenario
+  { input: { intervals: [[1,100], [11,22], [1,11], [2,12]] }, output: 2 },
+  // Added one more touching case for good measure
+  { input: { intervals: [[1, 2], [2, 3], [3, 4]] }, output: 0 },
+];


### PR DESCRIPTION
Adds required test cases to `packages/backend/src/problem/free/non-overlapping-intervals/testcase.ts`.

The test runner requires a minimum of 4 test cases. This commit adds 6 test cases covering various scenarios, including:
- Basic overlaps
- No overlaps
- Empty input
- Single interval input
- Touching intervals
- Complex overlaps

This resolves the error "Test cases count should be at least 4" during test execution for this problem.