### PR TITLE
feat(problem/minimumPathSum): Add test cases

### DIFF
--- a/packages/backend/src/problem/free/minimumPathSum/testcase.ts
+++ b/packages/backend/src/problem/free/minimumPathSum/testcase.ts
@@ -1,1 +1,28 @@
-export const testcases = [];
+import { TestCase } from "algo-lens-core";
+import { MinPathSumInput } from "./types";
+
+// Define the type for the test cases using the imported interfaces
+type MinPathSumTestCase = TestCase<MinPathSumInput, any>; // Use 'any' for State if not specifically typed
+
+export const testcases: MinPathSumTestCase[] = [
+  {
+    input: { grid: [[1, 3, 1], [1, 5, 1], [4, 2, 1]] },
+    expected: 7,
+    description: "Standard 3x3 grid",
+  },
+  {
+    input: { grid: [[1, 2, 3]] },
+    expected: 6,
+    description: "Single row grid",
+  },
+  {
+    input: { grid: [[1], [2], [3]] },
+    expected: 6,
+    description: "Single column grid",
+  },
+  {
+    input: { grid: [[1, 2], [1, 1]] },
+    expected: 3,
+    description: "Simple 2x2 grid",
+  },
+];


### PR DESCRIPTION
Adds four test cases to `minimumPathSum/testcase.ts` to satisfy the test runner's requirement of at least 4 test cases.

Includes tests for:
- A standard 3x3 grid
- A single-row grid
- A single-column grid
- A 2x2 grid

This resolves the error "Test cases count should be at least 4".