### PR TITLE
Fix(number-of-1-bits): Initialize StepLoggerV2 group options

### DIFF
--- a/packages/backend/src/problem/free/number-of-1-bits/steps.ts
+++ b/packages/backend/src/problem/free/number-of-1-bits/steps.ts
@@ -1,10 +1,18 @@
 import { ProblemState } from "algo-lens-core";
 import { StepLoggerV2 } from "../../core/StepLoggerV2"; // Import StepLoggerV2
 import { HammingWeightInput } from "./types";
+import { problem } from "./problem";
 
 export function generateSteps(p: HammingWeightInput): ProblemState[] {
   const { n } = p;
   const l = new StepLoggerV2(); // Instantiate StepLoggerV2
+
+  // Initialize group options from problem metadata
+  if (problem.metadata?.groups) {
+    for (const group of problem.metadata.groups) {
+      l.groupOptions.set(group.id, group);
+    }
+  }
 
   let count = 0;
   let maskingBit = 1;


### PR DESCRIPTION
The test for the 'number-of-1-bits' problem was failing with the error "no options for this group: input". This occurred because the StepLoggerV2 instance used within the `generateSteps` function was not initialized with the necessary group options defined in the problem's metadata.

This commit fixes the issue by:
1. Importing the `problem` definition into `steps.ts`.
2. Adding code within `generateSteps` to iterate over `problem.metadata.groups` and populate the `groupOptions` map of the StepLoggerV2 instance after its creation.

This ensures that the `group()` method in StepLoggerV2 can find the required options, resolving the runtime error.