### PR TITLE
fix(backend): Correct path construction in core test runner

### DIFF
--- a/packages/backend/src/problem/core/test.ts
+++ b/packages/backend/src/problem/core/test.ts
@@ -11,6 +11,8 @@ export function runTests(problem: Problem<any, ProblemState>) {
   // Check for TypeScript compilation errors
   const tsFilePath = path.join(
     process.cwd(), // Assuming the test runs from the repo root
+    "packages",
+    "backend",
     "src",
     "problem",
     "free",


### PR DESCRIPTION
The core test runner in `packages/backend/src/problem/core/test.ts` was constructing an incorrect path to locate TypeScript solution files for problems. It was missing the `packages/backend` segment, assuming files were directly under the root `src` directory.

This commit updates the `path.join` call to include `packages/backend` when building the `tsFilePath`, ensuring that the test runner can correctly find and validate TypeScript solutions within the monorepo structure.

Fixes the "TypeScript file not found" error during test execution for problems like 'missing-number'.