### PR TITLE
Fix: Resolve test errors related to assertions and logging

### DIFF
--- a/packages/backend/src/problem/core/test.ts
+++ b/packages/backend/src/problem/core/test.ts
@@ -62,24 +62,31 @@ export async function runTests(problem: Problem<any, ProblemState>) {
   if (testcases.length < 4) {
     throw new Error("Test cases count should be at least 4");
   }
-  for (const testcase of problem.testcases) {
-    const input = cloneDeep(testcase.input);
-    const expected = cloneDeep(testcase.expected);
-    for (const func of [problem.func]) {
-      const states = func(input);
 
-      const state = last(states);
-      const variables = state!.variables;
-      const result = variables.find((x) => x.label === "result");
-      if (!result) {
-        throw new Error("No result found in last state");
+  problem.testcases.forEach((testcase, index) => {
+    it(`Test case ${index + 1}`, () => {
+      const input = cloneDeep(testcase.input);
+      const expected = cloneDeep(testcase.expected);
+      for (const func of [problem.func]) {
+        const states = func(input);
+
+        const state = last(states);
+        const variables = state!.variables;
+        const result = variables.find((x) => x.label === "result");
+        if (!result) {
+          throw new Error("No result found in last state");
+        }
+        //@ts-expect-error
+        const value = result.value ?? result.values;
+        expect(value).toEqual(expected);
+        /**
+          console.log(
+            `Test case passed: ${JSON.stringify(input)} -> ${JSON.stringify(
+        */
       }
-      //@ts-expect-error
-      const value = result.value ?? result.values;
-      expect(value).toEqual(expected);
-      /**
-    console.log(
-      `Test case passed: ${JSON.stringify(input)} -> ${JSON.stringify(
+    });
+  });
+}
         value
       )}`
     );

--- a/packages/backend/src/problem/free/number-of-1-bits/steps.ts
+++ b/packages/backend/src/problem/free/number-of-1-bits/steps.ts
@@ -11,10 +11,12 @@ export function generateSteps(p: HammingWeightInput): ProblemState[] {
   let i = 0;
 
   // Initial state log
-  l.group("input", { n }); // Log initial input 'n'
+  // Set default options for groups if needed, or pass them directly
+  // Example: l.groupOptions.set('count', { min: 0, max: 32 });
+  l.group("input", { n }, { min: 0, max: n }); // Log initial input 'n' with options
   l.binary("n", n, { pointersRight: [i] }); // Log 'n' in binary with pointer
   l.binary("maskingBit", maskingBit, { pointersLeft: [0] }); // Log 'maskingBit' in binary with pointer
-  l.group("count", { count }); // Log initial 'count'
+  l.group("count", { count }, { min: 0, max: 32 }); // Log initial 'count' with options
   l.breakpoint(1);
 
   //#2 Start the loop to count the number of 1-bits
@@ -24,7 +26,7 @@ export function generateSteps(p: HammingWeightInput): ProblemState[] {
     //#3 Check if the least significant bit is 1
     if (n & maskingBit) {
       count++;
-      l.group("count", { count }); // Update count display
+      l.group("count", { count }, { min: 0, max: 32 }); // Update count display with options
       l.breakpoint(3);
     }
 


### PR DESCRIPTION
- Refactored `problem/core/test.ts` to wrap test case assertions within dynamic `it` blocks. This resolves the `TestNotRunningError: expect() must be called in a test` errors seen in several problem tests (e.g., same-tree, number-of-1-bits, container-with-most-water).

- Added missing options object (min/max values) to `logger.group()` calls within `problem/free/number-of-1-bits/steps.ts`. This resolves the `error: no options for this group: input` that was appearing in the test output, originating from this problem's step generation.