### PR TITLE
Refactor: Standardize problem test files

### DIFF
--- a/packages/backend/src/problem/free/3sum/index.test.ts
+++ b/packages/backend/src/problem/free/3sum/index.test.ts
@@ -1,9 +1,7 @@
-
 import { it } from "bun:test";
 import { problem } from "./problem";
 import { runTests } from "../../core/test";
 
-it(problem.id, () => {
-  runTests(problem);
+it(problem.id, async () => {
+  await runTests(problem);
 });
-

--- a/packages/backend/src/problem/free/bestTimeToBuyAndSellStocks/index.test.ts
+++ b/packages/backend/src/problem/free/bestTimeToBuyAndSellStocks/index.test.ts
@@ -1,8 +1,7 @@
 import { it } from "bun:test";
-import { problem } from "./problem"; // Assuming problem definition is exported from problem.ts
+import { problem } from "./problem";
 import { runTests } from "../../core/test";
 
-it(problem.id, () => {
-  runTests(problem); // Pass both problem and testcases to runTests
+it(problem.id, async () => {
+  await runTests(problem);
 });
-

--- a/packages/backend/src/problem/free/climbingStairs/index.test.ts
+++ b/packages/backend/src/problem/free/climbingStairs/index.test.ts
@@ -1,7 +1,7 @@
 import { it } from "bun:test";
-import { problem } from "./problem"; // Assuming problem definition is exported from problem.ts
+import { problem } from "./problem";
 import { runTests } from "../../core/test";
 
-it(problem.id, () => {
-  runTests(problem); // Pass both problem and testcases to runTests
+it(problem.id, async () => {
+  await runTests(problem);
 });

--- a/packages/backend/src/problem/free/coinChange/index.test.ts
+++ b/packages/backend/src/problem/free/coinChange/index.test.ts
@@ -1,7 +1,7 @@
 import { it } from "bun:test";
-import { problem } from "./problem"; // Assuming problem definition is exported from problem.ts
+import { problem } from "./problem";
 import { runTests } from "../../core/test";
 
-it(problem.id, () => {
-  runTests(problem); // Pass both problem and testcases to runTests
+it(problem.id, async () => {
+  await runTests(problem);
 });

--- a/packages/backend/src/problem/free/container-with-most-water/index.test.ts
+++ b/packages/backend/src/problem/free/container-with-most-water/index.test.ts
@@ -1,8 +1,7 @@
-import { runTests } from "../../core/test";
-import { problem } from "./problem";
 import { it } from "bun:test";
+import { problem } from "./problem";
+import { runTests } from "../../core/test";
 
-// Placeholder for Jest tests, if needed in the future.
 it(problem.id, async () => {
   await runTests(problem);
 });

--- a/packages/backend/src/problem/free/contains-duplicate/index.test.ts
+++ b/packages/backend/src/problem/free/contains-duplicate/index.test.ts
@@ -2,7 +2,6 @@ import { it } from "bun:test";
 import { problem } from "./problem";
 import { runTests } from "../../core/test";
 
-it(problem.id, () => {
-  // Assuming runTests can handle comparing final ProblemState variables
-  runTests(problem);
+it(problem.id, async () => {
+  await runTests(problem);
 });

--- a/packages/backend/src/problem/free/countingBits/index.test.ts
+++ b/packages/backend/src/problem/free/countingBits/index.test.ts
@@ -1,8 +1,7 @@
 import { it } from "bun:test";
-import { problem } from "./problem"; 
+import { problem } from "./problem";
 import { runTests } from "../../core/test";
 
-it(problem.id, () => {
-  // Assuming runTests can handle comparing final ProblemState variables (like the result array)
-  runTests(problem); 
+it(problem.id, async () => {
+  await runTests(problem);
 });

--- a/packages/backend/src/problem/free/course-schedule/index.test.ts
+++ b/packages/backend/src/problem/free/course-schedule/index.test.ts
@@ -2,6 +2,6 @@ import { it } from "bun:test";
 import { problem } from "./problem";
 import { runTests } from "../../core/test";
 
-it(problem.id, () => {
-  runTests(problem);
+it(problem.id, async () => {
+  await runTests(problem);
 });

--- a/packages/backend/src/problem/free/editDistance/index.test.ts
+++ b/packages/backend/src/problem/free/editDistance/index.test.ts
@@ -2,6 +2,6 @@ import { it } from "bun:test";
 import { problem } from "./problem";
 import { runTests } from "../../core/test";
 
-it(problem.id, () => {
-  runTests(problem);
+it(problem.id, async () => {
+  await runTests(problem);
 });

--- a/packages/backend/src/problem/free/houseRobber/index.test.ts
+++ b/packages/backend/src/problem/free/houseRobber/index.test.ts
@@ -2,6 +2,6 @@ import { it } from "bun:test";
 import { problem } from "./problem";
 import { runTests } from "../../core/test";
 
-it(problem.id, () => {
-  runTests(problem);
+it(problem.id, async () => {
+  await runTests(problem);
 });

--- a/packages/backend/src/problem/free/insert-interval/index.test.ts
+++ b/packages/backend/src/problem/free/insert-interval/index.test.ts
@@ -2,6 +2,6 @@ import { it } from "bun:test";
 import { problem } from "./problem";
 import { runTests } from "../../core/test";
 
-it(problem.id, () => {
-  runTests(problem);
+it(problem.id, async () => {
+  await runTests(problem);
 });

--- a/packages/backend/src/problem/free/longestIncreasingSubsequence/index.test.ts
+++ b/packages/backend/src/problem/free/longestIncreasingSubsequence/index.test.ts
@@ -1,7 +1,7 @@
-import { test } from "bun:test";
+import { it } from "bun:test";
 import { problem } from "./problem";
 import { runTests } from "../../core/test";
 
-test(problem.id, () => {
-  runTests(problem);
-})
+it(problem.id, async () => {
+  await runTests(problem);
+});

--- a/packages/backend/src/problem/free/maximum-subarray/index.test.ts
+++ b/packages/backend/src/problem/free/maximum-subarray/index.test.ts
@@ -2,6 +2,6 @@ import { it } from "bun:test";
 import { problem } from "./problem";
 import { runTests } from "../../core/test";
 
-it(problem.id, () => {
-  runTests(problem);
+it(problem.id, async () => {
+  await runTests(problem);
 });

--- a/packages/backend/src/problem/free/merge-intervals/index.test.ts
+++ b/packages/backend/src/problem/free/merge-intervals/index.test.ts
@@ -2,6 +2,6 @@ import { it } from "bun:test";
 import { problem } from "./problem";
 import { runTests } from "../../core/test";
 
-it(problem.id, () => {
-  runTests(problem);
+it(problem.id, async () => {
+  await runTests(problem);
 });

--- a/packages/backend/src/problem/free/minimumPathSum/index.test.ts
+++ b/packages/backend/src/problem/free/minimumPathSum/index.test.ts
@@ -2,6 +2,6 @@ import { it } from "bun:test";
 import { problem } from "./problem";
 import { runTests } from "../../core/test";
 
-it(problem.id, () => {
-  runTests(problem);
+it(problem.id, async () => {
+  await runTests(problem);
 });

--- a/packages/backend/src/problem/free/missing-number/index.test.ts
+++ b/packages/backend/src/problem/free/missing-number/index.test.ts
@@ -2,6 +2,6 @@ import { it } from "bun:test";
 import { problem } from "./problem";
 import { runTests } from "../../core/test";
 
-it(problem.id, () => {
-  runTests(problem);
+it(problem.id, async () => {
+  await runTests(problem);
 });

--- a/packages/backend/src/problem/free/non-overlapping-intervals/index.test.ts
+++ b/packages/backend/src/problem/free/non-overlapping-intervals/index.test.ts
@@ -2,6 +2,6 @@ import { it } from "bun:test";
 import { problem } from "./problem";
 import { runTests } from "../../core/test";
 
-it(problem.id, () => {
-  runTests(problem);
+it(problem.id, async () => {
+  await runTests(problem);
 });

--- a/packages/backend/src/problem/free/number-of-1-bits/index.test.ts
+++ b/packages/backend/src/problem/free/number-of-1-bits/index.test.ts
@@ -2,6 +2,6 @@ import { it } from "bun:test";
 import { problem } from "./problem";
 import { runTests } from "../../core/test";
 
-it(problem.id, () => {
-  runTests(problem);
+it(problem.id, async () => {
+  await runTests(problem);
 });

--- a/packages/backend/src/problem/free/number-of-islands/index.test.ts
+++ b/packages/backend/src/problem/free/number-of-islands/index.test.ts
@@ -1,8 +1,7 @@
-import { runTests } from "../../core/test";
-import { problem } from "./problem";
 import { it } from "bun:test";
+import { problem } from "./problem";
+import { runTests } from "../../core/test";
 
-// Placeholder for Jest tests, if needed in the future.
-it(problem.id, () => {
-  runTests(problem);
+it(problem.id, async () => {
+  await runTests(problem);
 });

--- a/packages/backend/src/problem/free/pacific-atlantic-water-flow/index.test.ts
+++ b/packages/backend/src/problem/free/pacific-atlantic-water-flow/index.test.ts
@@ -2,6 +2,6 @@ import { it } from "bun:test";
 import { problem } from "./problem";
 import { runTests } from "../../core/test";
 
-it(problem.id, () => {
-  runTests(problem);
+it(problem.id, async () => {
+  await runTests(problem);
 });

--- a/packages/backend/src/problem/free/product-of-array-except-self/index.test.ts
+++ b/packages/backend/src/problem/free/product-of-array-except-self/index.test.ts
@@ -1,8 +1,7 @@
 import { it } from "bun:test";
 import { problem } from "./problem";
-import { runTests } from "../../core/test"; // Adjusted path assuming core/test is two levels up
+import { runTests } from "../../core/test";
 
-// Run the tests for the product-of-array-except-self problem
-it(problem.id, () => {
-  runTests(problem);
+it(problem.id, async () => {
+  await runTests(problem);
 });

--- a/packages/backend/src/problem/free/reverse-list/index.test.ts
+++ b/packages/backend/src/problem/free/reverse-list/index.test.ts
@@ -2,6 +2,6 @@ import { it } from "bun:test";
 import { problem } from "./problem";
 import { runTests } from "../../core/test";
 
-it(problem.id, () => {
-  runTests(problem);
+it(problem.id, async () => {
+  await runTests(problem);
 });

--- a/packages/backend/src/problem/free/search-in-rotated-sorted-array/index.test.ts
+++ b/packages/backend/src/problem/free/search-in-rotated-sorted-array/index.test.ts
@@ -1,7 +1,7 @@
 import { it } from "bun:test";
-import { problem } from "./problem"; // Import from problem.ts
-import { runTests } from "../../core/test"; // Adjust path relative to the new test file
+import { problem } from "./problem";
+import { runTests } from "../../core/test";
 
-it(problem.id, () => {
-  runTests(problem);
+it(problem.id, async () => {
+  await runTests(problem);
 });

--- a/packages/backend/src/problem/free/sum-of-two-integers/index.test.ts
+++ b/packages/backend/src/problem/free/sum-of-two-integers/index.test.ts
@@ -1,7 +1,7 @@
 import { it } from "bun:test";
-import { problem } from "./problem"; // Import from the sibling .ts file
-import { runTests } from "../../core/test"; // Adjust path relative to the new test file
+import { problem } from "./problem";
+import { runTests } from "../../core/test";
 
-it(problem.id, () => {
-  runTests(problem);
+it(problem.id, async () => {
+  await runTests(problem);
 });

--- a/packages/backend/src/problem/free/two-sum/index.test.ts
+++ b/packages/backend/src/problem/free/two-sum/index.test.ts
@@ -1,7 +1,7 @@
-import { it } from "bun:test"; // Assuming bun:test based on project structure
+import { it } from "bun:test";
 import { problem } from "./problem";
 import { runTests } from "../../core/test";
 
-it(problem.id, () => {
-  runTests(problem);
+it(problem.id, async () => {
+  await runTests(problem);
 });

--- a/packages/backend/src/problem/free/unique-paths/index.test.ts
+++ b/packages/backend/src/problem/free/unique-paths/index.test.ts
@@ -1,7 +1,7 @@
+import { it } from "bun:test";
 import { problem } from "./problem";
 import { runTests } from "../../core/test";
-import { it } from "bun:test";
 
-it(problem.id, () => {
-  runTests(problem);
+it(problem.id, async () => {
+  await runTests(problem);
 });

--- a/packages/backend/src/problem/free/word-break/index.test.ts
+++ b/packages/backend/src/problem/free/word-break/index.test.ts
@@ -1,7 +1,7 @@
 import { it } from "bun:test";
-import { problem } from "./problem"; // Import from the sibling .ts file
-import { runTests } from "../../core/test"; // Adjust path relative to the new test file
+import { problem } from "./problem";
+import { runTests } from "../../core/test";
 
-it(problem.id, () => {
-  runTests(problem);
+it(problem.id, async () => {
+  await runTests(problem);
 });


### PR DESCRIPTION
I updated the `index.test.ts` file for each problem within `packages/backend/src/problem/free/` to use a consistent format.

The new format uses `bun:test`, imports the `problem` definition from the local `problem.ts`, and utilizes the `runTests` function from `../../core/test` for execution.

This ensures uniformity across all problem tests.