### PR TITLE
Refactor: Use StepLoggerV2 for non-overlapping-intervals

### DIFF
--- a/packages/backend/src/problem/free/non-overlapping-intervals/steps.ts
+++ b/packages/backend/src/problem/free/non-overlapping-intervals/steps.ts
@@ -1,6 +1,6 @@
-import { ProblemState, Variable } from "algo-lens-core"; // Removed IntervalVariable, Problem
+import { ProblemState, Variable } from "algo-lens-core";
+import { StepLoggerV2 } from "../../core/StepLoggerV2"; // Import StepLoggerV2
 import {
-  // Removed unused imports
   asValueGroup,
   asIntervals,
   getIntervalBounds,
@@ -11,55 +11,49 @@ export function generateSteps( // Renamed and Exported
   p: EraseOverlapIntervalsInput
 ): ProblemState[] {
   const { intervals } = p;
-  const steps: ProblemState[] = [];
+  const logger = new StepLoggerV2(["intervals", "remainingIntervals", "removalCount", "i"]); // Instantiate StepLoggerV2
+
   let removalCount = 0; //#1 Initialize removal count
   const remainingIntervals: number[][] = [];
 
-  function log(point: number, i?: number) {
-    const v: Variable[] = [];
-    const step: ProblemState = {
-      variables: v,
-      breakpoint: point,
-    };
-    const { min, max } = getIntervalBounds(intervals);
-    v.push(asIntervals("intervals", intervals, [i], min, max));
-    v.push(asIntervals("remainingIntervals", remainingIntervals, [], min, max));
-    v.push(
-      asValueGroup(
-        "removalCount",
-        { removalCount },
-        { min: 0, max: intervals.length }
-      )
-    );
-    steps.push(step);
-  }
+  // Define variable scopes and types for the logger
+  const { min, max } = getIntervalBounds(intervals);
+  logger.setVariableProps("intervals", { type: "intervals", min, max });
+  logger.setVariableProps("remainingIntervals", { type: "intervals", min, max });
+  logger.setVariableProps("removalCount", {
+    type: "valueGroup",
+    min: 0,
+    max: intervals.length,
+  });
+  logger.setVariableProps("i", { type: "index", range: [0, intervals.length -1] });
+
 
   // Initial state log before the loop starts
-  log(1);
+  logger.log(1, { intervals, remainingIntervals, removalCount }); //#1 Log initial state
 
   intervals.sort((a, b) => a[1] - b[1]); //#2 Sort the intervals by end points
-  log(2);
+  logger.log(2, { intervals, remainingIntervals, removalCount }); //#2 Log after sort
+
   let lastEnd = Number.MIN_SAFE_INTEGER;
   for (let i = 0; i < intervals.length; i++) {
     const currentStart = intervals[i][0];
     const currentEnd = intervals[i][1];
-    log(3, i); //#3 Iterate through the intervals
+    logger.log(3, { intervals, remainingIntervals, removalCount, i }); //#3 Iterate through the intervals
     if (currentStart < lastEnd) {
       // Increment removal count if there is an overlap
       removalCount++;
-      log(4, i); //#4 Log overlapping case
+      logger.log(4, { intervals, remainingIntervals, removalCount, i }); //#4 Log overlapping case
     } else {
       // Update the end point and record the interval
       lastEnd = currentEnd;
       remainingIntervals.push(intervals[i]);
-      log(5, i); //#5 Update non-overlapping intervals
+      logger.log(5, { intervals, remainingIntervals, removalCount, i }); //#5 Update non-overlapping intervals
     }
   }
 
-  log(6); //#6 Final log after all calculations - Restored
+  logger.log(6, { intervals, remainingIntervals, removalCount }); //#6 Final log after all calculations
 
-
-  return steps;
+  return logger.getSteps(); // Return steps from the logger
 }
 
 // Removed EraseOverlapIntervalsInput interface, code, title, getInput, tested flag, Problem export


### PR DESCRIPTION
Replaced the manual step generation logic in
`packages/backend/src/problem/free/non-overlapping-intervals/steps.ts` with the StepLoggerV2 class.

This standardizes the step logging approach for this problem, aligning it with other problems using StepLoggerV2. The core logic for generating steps remains the same, capturing the state of variables at relevant breakpoints.