### PR TITLE
Refactor: Use StepLoggerV2 in word-break problem

### DIFF
--- a/packages/backend/src/problem/free/word-break/code/index.ts
+++ b/packages/backend/src/problem/free/word-break/code/index.ts
@@ -1,58 +1,42 @@
-import { clone } from "lodash"; // Keep this if needed, seems unused now but maybe later?
 import { ProblemState } from "algo-lens-core"; // Import ProblemState
-import { asArray, asValueGroup, asSimpleValue, asStringArray } from "../../core/utils";
+import { StepLoggerV2 } from "../../core/StepLoggerV2"; // Import StepLoggerV2
 import { WordBreakInput } from "../types"; // Import from ../types
 
 export function wordBreak(p: WordBreakInput): ProblemState[] {
-  const s: ProblemState[] = [];
-  const { s: str, wordDict } = p;
+  const logger = new StepLoggerV2();
+  const { s: strInput, wordDict } = p; // Renamed s to strInput to avoid conflict
+  const str = strInput.split(''); // Convert string to char array for logger
   const n = str.length;
   const dp: boolean[] = new Array(n + 1).fill(false);
   dp[0] = true; // Empty string can always be segmented.
-  s.push({
-    variables: [asStringArray("str", str), asArray("dp", dp)],
-    breakpoint: 1,
-  }); //#1
+  logger.arrayV2({ name: "str", state: str });
+  logger.arrayV2({ name: "dp", state: dp });
+  logger.breakpoint(1); //#1
 
   for (let i = 1; i <= n; i++) {
     for (let j = 0; j < i; j++) {
-      const word = str.substring(j, i);
-      s.push({
-        variables: [
-          asStringArray("str", str, i - 1, j),
-          asValueGroup("loops",{ i, j }, { min: 0, max: n }),
-          ...asSimpleValue({ word }),
-          asArray("dp", dp, i, j),
-        ],
-        breakpoint: 2,
-      }); //#2
+      const word = strInput.substring(j, i); // Use original string for substring
+      logger.arrayV2({ name: "str", state: str }, { head: i - 1, tail: j });
+      logger.group("loops", { i, j }, { meta: { min: 0, max: n } });
+      logger.simple({ word });
+      logger.arrayV2({ name: "dp", state: dp }, { head: i, tail: j });
+      logger.breakpoint(2); //#2
       if (dp[j] && wordDict.includes(word)) {
         dp[i] = true;
-        s.push({
-          variables: [
-            asStringArray("str", str, i - 1, j),
-            ...asSimpleValue({  word }),
-            asValueGroup("loops",{ i, j }, { min: 0, max: n }),
-            asArray("dp", dp, i, j),
-          ],
-          breakpoint: 3,
-        });
-        //#3
+        logger.arrayV2({ name: "str", state: str }, { head: i - 1, tail: j });
+        logger.simple({ word });
+        logger.group("loops", { i, j }, { meta: { min: 0, max: n } });
+        logger.arrayV2({ name: "dp", state: dp }, { head: i, tail: j });
+        logger.breakpoint(3); //#3
         break;
       }
     }
   }
 
   const result = dp[n];
-  s.push({
-    variables: [
-      asStringArray("str", str),
-      ...asSimpleValue({
-        result,
-      }),
-      asArray("dp", dp, n),
-    ],
-    breakpoint: 4,
-  }); //#4
-  return s;
+  logger.arrayV2({ name: "str", state: str });
+  logger.simple({ result });
+  logger.arrayV2({ name: "dp", state: dp }, { head: n });
+  logger.breakpoint(4); //#4
+  return logger.getSteps();
 }


### PR DESCRIPTION
I replaced the manual step logging implementation within the `wordBreak` function (`packages/backend/src/problem/free/word-break/code/index.ts`) with the standardized `StepLoggerV2`.

This involved:
- Instantiating `StepLoggerV2`.
- Replacing manual `ProblemState` creation with calls to `logger.arrayV2`, `logger.simple`, `logger.group`, and `logger.breakpoint`.
- Returning `logger.getSteps()`.

The core algorithm logic remains unchanged. Existing tests comparing the function's output against a reference solution are sufficient to verify the correctness of the generated steps.