### PR TITLE
Refactor: Align sum-of-two-integers with 3sum structure

### DIFF
--- a/packages/backend/src/problem/free/sum-of-two-integers/code/typescript.ts
+++ b/packages/backend/src/problem/free/sum-of-two-integers/code/typescript.ts
@@ -1,5 +1,10 @@
 // Placeholder for sum-of-two-integers implementation
-export  function getSum(a: number, b: number): number {
-  // TODO: Implement the actual logic without using '+' or '-' operators
-  return a + b; // Temporary basic implementation
+export function getSum(a: number, b: number): number {
+  let carry: number;
+  while (b !== 0) {
+    carry = (a & b); // Calculate carry
+    a = a ^ b;       // Calculate sum without carry
+    b = carry << 1;  // Shift carry to be added in the next iteration
+  }
+  return a; // Final result is in 'a' when 'b' becomes 0
 }

--- a/packages/backend/src/problem/free/sum-of-two-integers/problem.ts
+++ b/packages/backend/src/problem/free/sum-of-two-integers/problem.ts
@@ -1,124 +1,25 @@
-import {
-  Problem,
-  ProblemState,
-  Variable,
-  BinaryVariable,
-} from "algo-lens-core";
+import { Problem, ProblemState } from "algo-lens-core";
+import { generateSteps } from "./steps";
 
-// Defines the interface for the input expected by the sumOfTwoIntegers function
+// Defines the interface for the input expected by the generateSteps function
 interface SumOfTwoIntegersInput {
   a: number;
   b: number;
 }
 
-export function asBinary(
-  o: Record<string, number>,
-  options?: {
-    highlightLast?: boolean;
-    pointersLeft?: number[];
-    pointersRight?: number[];
-  }
-): BinaryVariable {
-  const keys = Object.keys(o);
-  if (keys.length != 1) {
-    throw new Error("asBinary only supports one key");
-  }
-  const [label] = keys;
-  const value = o[label];
+// asBinary function removed - no longer needed here.
 
-  const result: BinaryVariable = {
-    label,
-    type: "binary",
-    value: value,
-    pointers: [],
-  };
-  const asBinaryString = value.toString(2);
-  if (options?.highlightLast) {
-    const lastIndex = asBinaryString.length - 1;
-    result.pointers.push({
-      value: lastIndex,
-      dimension: "column",
-    });
-  }
-  for (const pointer in options?.pointersLeft ?? []) {
-    result.pointers.push({
-      value: options?.pointersLeft[pointer],
-      dimension: "column",
-    });
-  }
+// sumOfTwoIntegers function removed - logic moved to steps.ts
 
-  for (const pointer in options?.pointersRight ?? []) {
-    result.pointers.push({
-      value: asBinaryString.length - 1 - options?.pointersRight[pointer],
-      dimension: "column",
-    });
-  }
+// code variable removed - no longer needed here.
 
-  return result;
-}
-
-/**
- * Implements the sum of two integers algorithm using bitwise operations.
- * @param p - The input parameters including two integers.
- * @returns The states showing the steps of the computation.
- */
-export function sumOfTwoIntegers(p: SumOfTwoIntegersInput): ProblemState[] {
-  const s: ProblemState[] = [];
-  let { a, b } = p;
-  let carry: number;
-
-  function log(point: number) {
-    const v: Variable[] = [
-      asBinary({ a }, { highlightLast: true }),
-      asBinary({ b }, { highlightLast: true }),
-    ];
-    if (carry !== undefined) {
-      v.push(asBinary({ carry }, { highlightLast: true }));
-    }
-    const step: ProblemState = {
-      variables: v,
-      breakpoint: point,
-    };
-    s.push(step);
-  }
-
-  log(1); // Initial state
-  while (b !== 0) {
-    carry = a & b;
-    log(2);
-    a = a ^ b;
-    log(3);
-    b = carry << 1;
-    log(4);
-  }
-
-  log(5); // Final state
-
-  return s;
-}
-
-// Example implementation of the sumOfTwoIntegers function for demonstration and testing
-const code = `function sumOfTwoIntegers(a: number, b: number): number {
-  //#1
-  while (b !== 0) {
-    let carry = a & b;
-    //#2 Calculate carry
-    
-    a = a ^ b;
-    //#3 Calculate sum without carry
-    
-    b = carry << 1;
-    //#4 Shift carry
-  }
-  //#5 Return the result
-  return a;
-}`;
-
-// Export the complete problem setup including the input function, the computational function, and other metadata
-export const problem: Problem<SumOfTwoIntegersInput, number> = {
+// Export the complete problem setup
+// Note: The second type argument is ProblemState[], as generateSteps returns an array of states.
+export const problem: Problem<SumOfTwoIntegersInput, ProblemState[]> = {
   title: "Sum of Two Integers",
   emoji: "➕",
-  func: sumOfTwoIntegers,
+  // The func now calls generateSteps with the input parameters a and b.
+  func: (p: SumOfTwoIntegersInput) => generateSteps(p.a, p.b),
   id: "sum-of-two-integers",
   tags: ["bit manipulation"],
 };

--- a/packages/backend/src/problem/free/sum-of-two-integers/steps.ts
+++ b/packages/backend/src/problem/free/sum-of-two-integers/steps.ts
@@ -1,0 +1,53 @@
+import { ProblemState } from "algo-lens-core";
+import { StepLoggerV2 } from "../../core/StepLoggerV2";
+// import { asBinary } from "../../core/utils"; // Not needed if StepLoggerV2 handles {varName: value}
+
+/**
+ * Generates the states for the sum of two integers algorithm using bitwise operations.
+ * @param a - The first integer.
+ * @param b - The second integer.
+ * @returns The states showing the steps of the computation.
+ */
+export function generateSteps(a: number, b: number): ProblemState[] {
+  const l = new StepLoggerV2();
+  let carry: number | undefined; // Define carry outside the loop
+
+  // Initial state (Breakpoint 1)
+  l.binary({ a });
+  l.binary({ b });
+  l.breakpoint(1);
+
+  while (b !== 0) {
+    carry = a & b;
+    // State after calculating carry (Breakpoint 2)
+    l.binary({ a });
+    l.binary({ b });
+    l.binary({ carry });
+    l.breakpoint(2);
+
+    a = a ^ b;
+    // State after calculating sum without carry (Breakpoint 3)
+    l.binary({ a });
+    l.binary({ b });
+    l.binary({ carry });
+    l.breakpoint(3);
+
+    b = carry << 1;
+    // State after shifting carry (Breakpoint 4)
+    l.binary({ a });
+    l.binary({ b }); // b now holds the shifted carry
+    l.binary({ carry });
+    l.breakpoint(4);
+  }
+
+  // Final state (Breakpoint 5)
+  l.binary({ a }); // Final result is in a
+  l.binary({ b }); // b should be 0 here
+  // Optionally log the final carry if it was defined in the last iteration
+  if (carry !== undefined) {
+    l.binary({ carry });
+  }
+  l.breakpoint(5);
+
+  return l.getSteps();
+}


### PR DESCRIPTION
I've separated the step generation logic from the problem definition for the 'sum-of-two-integers' problem.

- I created a new `steps.ts` file containing a `generateSteps` function.
- I implemented `generateSteps` using `StepLoggerV2` to capture the state of bitwise operations, mirroring the pattern used in problems like '3sum'.
- I updated the core logic in `code/typescript.ts` to contain only the bitwise addition algorithm without logging calls.
- I refactored `problem.ts` to remove the old step generation logic and use the new `generateSteps` function via the `func` property.

I was unable to perform testing due to environment limitations.