### PR TITLE
Fix several test failures in backend problems

### DIFF
--- a/packages/backend/src/problem/free/merge-intervals/testcase.ts
+++ b/packages/backend/src/problem/free/merge-intervals/testcase.ts
@@ -14,4 +14,8 @@ export const testcases: TestCase<MergeIntervalsInput>[] = [
     input: { intervals: [[1, 3], [2, 6], [8, 10], [15, 18]] },
     expected: { intervals: [[1, 6], [8, 10], [15, 18]] },
   },
+  {
+    input: { intervals: [[1, 2], [3, 4], [5, 6]] },
+    expected: { intervals: [[1, 2], [3, 4], [5, 6]] },
+  },
 ];

--- a/packages/backend/src/problem/free/pacific-atlantic-water-flow/testcase.ts
+++ b/packages/backend/src/problem/free/pacific-atlantic-water-flow/testcase.ts
@@ -1,1 +1,65 @@
-export const testcases = [];
+import { TestCase } from "algo-lens-core";
+import { PacificAtlanticWaterFlowInput } from "./types";
+
+export const testcases: TestCase<PacificAtlanticWaterFlowInput>[] = [
+  {
+    input: {
+      heights: [
+        [1, 2, 2, 3, 5],
+        [3, 2, 3, 4, 4],
+        [2, 4, 5, 3, 1],
+        [6, 7, 1, 4, 5],
+        [5, 1, 1, 2, 4],
+      ],
+    },
+    expected: {
+      coordinates: [
+        [0, 4],
+        [1, 3],
+        [1, 4],
+        [2, 2],
+        [3, 0],
+        [3, 1],
+        [4, 0],
+      ],
+    },
+  },
+  {
+    input: { heights: [[1]] },
+    expected: { coordinates: [[0, 0]] },
+  },
+  {
+    input: {
+      heights: [
+        [1, 1],
+        [1, 1],
+        [1, 1],
+      ],
+    },
+    expected: {
+      coordinates: [
+        [0, 0],
+        [0, 1],
+        [1, 0],
+        [1, 1],
+        [2, 0],
+        [2, 1],
+      ],
+    },
+  },
+  {
+    input: {
+      heights: [
+        [1, 2],
+        [4, 3],
+      ],
+    },
+    expected: {
+      coordinates: [
+        [0, 1],
+        [1, 0],
+        [1, 1],
+      ],
+    },
+  },
+];

--- a/packages/backend/src/problem/free/sum-of-two-integers/groups.ts
+++ b/packages/backend/src/problem/free/sum-of-two-integers/groups.ts
@@ -1,0 +1,6 @@
+import { Group } from "algo-lens-core";
+
+export const groups: Group[] = [
+  { label: "Input", variables: ["a", "b"], highlight: true },
+  { label: "Output", variables: ["result"], highlight: true },
+];

--- a/packages/backend/src/problem/free/sum-of-two-integers/problem.ts
+++ b/packages/backend/src/problem/free/sum-of-two-integers/problem.ts
@@ -1,5 +1,7 @@
 import { Problem, ProblemState } from "algo-lens-core";
 import { generateSteps } from "./steps";
+import { groups } from "./groups";
+import { variables } from "./variables";
 
 // Defines the interface for the input expected by the generateSteps function
 interface SumOfTwoIntegersInput {
@@ -22,4 +24,8 @@ export const problem: Problem<SumOfTwoIntegersInput, ProblemState[]> = {
   func: (p: SumOfTwoIntegersInput) => generateSteps(p.a, p.b),
   id: "sum-of-two-integers",
   tags: ["bit manipulation"],
+  metadata: {
+    groups: groups,
+    variables: variables,
+  },
 };

--- a/packages/backend/src/problem/free/sum-of-two-integers/variables.ts
+++ b/packages/backend/src/problem/free/sum-of-two-integers/variables.ts
@@ -1,0 +1,7 @@
+import { Variable } from "algo-lens-core";
+
+export const variables: Variable[] = [
+  { label: "a", type: "integer" },
+  { label: "b", type: "integer" },
+  { label: "result", type: "integer" },
+];

--- a/packages/backend/src/problem/free/word-break/code/index.ts
+++ b/packages/backend/src/problem/free/word-break/code/index.ts
@@ -1,5 +1,5 @@
 import { ProblemState } from "algo-lens-core"; // Import ProblemState
-import { StepLoggerV2 } from "../../core/StepLoggerV2"; // Import StepLoggerV2
+import { StepLoggerV2 } from "../../../core/StepLoggerV2"; // Import StepLoggerV2
 import { WordBreakInput } from "../types"; // Import from ../types
 
 export function wordBreak(p: WordBreakInput): ProblemState[] {


### PR DESCRIPTION
This commit addresses the first three test failures identified by `bun run test`:

1.  **merge-intervals:** Added a fourth test case to `packages/backend/src/problem/free/merge-intervals/testcase.ts` to satisfy the minimum test case requirement (>= 4) in the core test runner.
2.  **sum-of-two-integers:** Added missing metadata (`groups` and `variables`) to the problem definition. Created `groups.ts` and `variables.ts` and updated `problem.ts` to include the `metadata` property, resolving the "No metadata found" error.
3.  **pacific-atlantic-water-flow:** Added four test cases to `packages/backend/src/problem/free/pacific-atlantic-water-flow/testcase.ts`, resolving the "Test cases count should be at least 4" error.

I stopped before addressing the remaining test failures for `word-break`, `reverse-list`, `non-overlapping-intervals`, and `number-of-1-bits`. The next step was to investigate the incorrect import path for `StepLoggerV2` in `word-break`.