### PR TITLE
Fix: Resolve multiple TypeScript errors across codebase

### DIFF
--- a/packages/backend/src/problem/core/utils.ts
+++ b/packages/backend/src/problem/core/utils.ts
@@ -85,12 +85,9 @@ export function asBooleanGroup(
   return result;
 }
 
-function addRandomIds(
-  tree: BinaryTreeNode | null,
-  i: number
-): number | undefined {
+function addRandomIds(tree: BinaryTreeNode | null, i: number): number {
   if (!tree) {
-    return undefined;
+    return i;
   }
 
   tree.id = i.toString();
@@ -202,25 +199,28 @@ export function asArray(
   column2?: number,
   column3?: number
 ): ArrayVariable {
-  const result: ArrayVariable = {
-    label,
-    type: "array",
-    value: cloneDeep(arr),
-    pointers: [
-      {
-        value: column1,
-        dimension: "column",
-      },
-      {
-        value: column2,
-        dimension: "column",
-      },
-      {
-        value: column3,
-        dimension: "column",
-      },
-    ],
+    pointers: [],
   };
+
+  if (column1 !== undefined) {
+    result.pointers.push({
+      value: column1,
+      dimension: "column",
+    });
+  }
+  if (column2 !== undefined) {
+    result.pointers.push({
+      value: column2,
+      dimension: "column",
+    });
+  }
+  if (column3 !== undefined) {
+    result.pointers.push({
+      value: column3,
+      dimension: "column",
+    });
+  }
+
   return result;
 }
 
@@ -250,7 +250,7 @@ export function asBinary(
   };
   const asBinaryString = value.toString(2);
   if (options?.highlightLast) {
-    //check what is index of last element of binary representation of the value number and set it as pointer
+    // check what is index of last element of binary representation of the value number and set it as pointer
     const lastIndex = asBinaryString.length - 1;
     result.pointers.push({
       value: lastIndex,
@@ -258,17 +258,23 @@ export function asBinary(
     });
   }
   for (const pointer in options?.pointersLeft ?? []) {
-    result.pointers.push({
-      value: options?.pointersLeft[pointer],
-      dimension: "column",
-    });
+    const value = options?.pointersLeft?.[pointer];
+    if (value !== undefined) {
+      result.pointers.push({
+        value,
+        dimension: "column",
+      });
+    }
   }
 
   for (const pointer in options?.pointersRight ?? []) {
-    result.pointers.push({
-      value: asBinaryString.length - 1 - options?.pointersRight[pointer],
-      dimension: "column",
-    });
+    const rightPointerValue = options?.pointersRight?.[pointer];
+    if (rightPointerValue !== undefined) {
+      result.pointers.push({
+        value: asBinaryString.length - 1 - rightPointerValue,
+        dimension: "column",
+      });
+    }
   }
 
   return result;
@@ -285,25 +291,26 @@ export function asStringArray(
   column2?: number,
   column3?: number
 ): ArrayVariable {
-  const result: ArrayVariable = {
-    label,
-    type: "array",
-    value: s.split(""),
-    pointers: [
-      {
-        value: column1,
-        dimension: "column",
-      },
-      {
-        value: column2,
-        dimension: "column",
-      },
-      {
-        value: column3,
-        dimension: "column",
-      },
-    ],
+    pointers: [],
   };
+  if (column1 !== undefined) {
+    result.pointers.push({
+      value: column1,
+      dimension: "column",
+    });
+  }
+  if (column2 !== undefined) {
+    result.pointers.push({
+      value: column2,
+      dimension: "column",
+    });
+  }
+  if (column3 !== undefined) {
+    result.pointers.push({
+      value: column3,
+      dimension: "column",
+    });
+  }
   return result;
 }
 

--- a/packages/backend/src/problem/free/bestTimeToBuyAndSellStocks/problem.ts
+++ b/packages/backend/src/problem/free/bestTimeToBuyAndSellStocks/problem.ts
@@ -12,6 +12,7 @@ export const problem: Problem<MaxProfitInput, ProblemState> = {
   emoji: "📈",
   func: generateSteps,
   id: "bestTimeToBuyAndSellStocks",
+  difficulty: "easy",
   testcases,
   tags: ["array"],
   metadata: {

--- a/packages/backend/src/problem/free/climbingStairs/code/typescript.ts
+++ b/packages/backend/src/problem/free/climbingStairs/code/typescript.ts
@@ -1,4 +1,4 @@
-export function climbStairs(n) {
+export function climbStairs(n: number) {
   // Initialize a dynamic programming array with n + 1 elements to hold the number of ways to reach each step
   const dp: number[] = new Array(n + 1).fill(0);
   dp[0] = 1; // Base case: one way to stand on the ground (step 0)

--- a/packages/backend/src/problem/free/contains-duplicate/steps.ts
+++ b/packages/backend/src/problem/free/contains-duplicate/steps.ts
@@ -15,7 +15,7 @@ export function generateSteps(nums: number[]): ProblemState[] {
 
   // Initial state log before the loop starts
   logger.arrayV2({ nums: nums }, {});
-  logger.hashset("hashSet", hashSet, {}); // Initial empty hashset state
+  logger.hashset("hashSet", hashSet, { value: -1, color: "neutral" }); // Initial empty hashset state
   logger.simple({ result }); // Initial result state
   logger.breakpoint(1);
 
@@ -47,7 +47,7 @@ export function generateSteps(nums: number[]): ProblemState[] {
 
   // Logs the final state when no duplicate is found
   logger.arrayV2({ nums: nums }, {}); // Final array state
-  logger.hashset("hashSet", hashSet, {}); // Final hashset state
+  logger.hashset("hashSet", hashSet, { value: -1, color: "neutral" }); // Final hashset state
   logger.simple({ result }); // Log final false result
   logger.breakpoint(5);
 

--- a/packages/backend/src/problem/free/course-schedule/steps.ts
+++ b/packages/backend/src/problem/free/course-schedule/steps.ts
@@ -15,8 +15,8 @@ export function generateSteps(numCourses: number, prerequisites: number[][]) {
 
   // Initial state log (Breakpoint 1)
   l.simple({ numCourses });
-  l.hashmap("prerequisites", from2dArrayToMap(prerequisites));
-  l.hashmap("graph", from2dArrayToMap(graph));
+  l.hashmap("prerequisites", from2dArrayToMap(prerequisites), { value: -1, color: "neutral" });
+  l.hashmap("graph", from2dArrayToMap(graph), { value: -1, color: "neutral" });
   l.arrayV2({ inDegree: inDegree }, {});
   l.arrayV2({ queue: queue }, {});
   l.breakpoint(1);
@@ -29,7 +29,7 @@ export function generateSteps(numCourses: number, prerequisites: number[][]) {
       value: prerequisitesIndex, // Highlight current prerequisite pair
       color: "primary",
     });
-    l.hashmap("graph", from2dArrayToMap(graph));
+    l.hashmap("graph", from2dArrayToMap(graph), { value: -1, color: "neutral" });
     l.arrayV2({ inDegree: inDegree }, { course: course }); // Highlight inDegree[course] before change
     l.arrayV2({ queue: queue }, {});
     l.breakpoint(2);
@@ -43,7 +43,7 @@ export function generateSteps(numCourses: number, prerequisites: number[][]) {
       value: prerequisitesIndex,
       color: "primary",
     });
-    l.hashmap("graph", from2dArrayToMap(graph)); // Graph now updated
+    l.hashmap("graph", from2dArrayToMap(graph), { value: -1, color: "neutral" }); // Graph now updated
     l.arrayV2({ inDegree: inDegree }, { course: course }); // Highlight inDegree[course] after change
     l.arrayV2({ queue: queue }, {});
     l.breakpoint(3);
@@ -51,8 +51,8 @@ export function generateSteps(numCourses: number, prerequisites: number[][]) {
 
   // Log after initialization loop (Breakpoint 4)
   l.simple({ numCourses });
-  l.hashmap("prerequisites", from2dArrayToMap(prerequisites));
-  l.hashmap("graph", from2dArrayToMap(graph));
+  l.hashmap("prerequisites", from2dArrayToMap(prerequisites), { value: -1, color: "neutral" });
+  l.hashmap("graph", from2dArrayToMap(graph), { value: -1, color: "neutral" });
   l.arrayV2({ inDegree: inDegree }, {});
   l.arrayV2({ queue: queue }, {});
   l.breakpoint(4);
@@ -61,8 +61,8 @@ export function generateSteps(numCourses: number, prerequisites: number[][]) {
   inDegree.forEach((deg, index) => {
     // Log before checking degree (Breakpoint 5)
     l.simple({ numCourses, deg });
-    l.hashmap("prerequisites", from2dArrayToMap(prerequisites));
-    l.hashmap("graph", from2dArrayToMap(graph));
+    l.hashmap("prerequisites", from2dArrayToMap(prerequisites), { value: -1, color: "neutral" });
+    l.hashmap("graph", from2dArrayToMap(graph), { value: -1, color: "neutral" });
     l.arrayV2({ inDegree: inDegree }, { index: index }); // Highlight current degree being checked
     l.arrayV2({ queue: queue }, {});
     l.breakpoint(5);
@@ -70,8 +70,8 @@ export function generateSteps(numCourses: number, prerequisites: number[][]) {
     if (deg === 0) {
       // Log before adding to queue (Breakpoint 6)
       l.simple({ numCourses, deg });
-      l.hashmap("prerequisites", from2dArrayToMap(prerequisites));
-      l.hashmap("graph", from2dArrayToMap(graph));
+      l.hashmap("prerequisites", from2dArrayToMap(prerequisites), { value: -1, color: "neutral" });
+      l.hashmap("graph", from2dArrayToMap(graph), { value: -1, color: "neutral" });
       l.arrayV2({ inDegree: inDegree }, { index: index });
       l.arrayV2({ queue: queue }, {});
       l.breakpoint(6);
@@ -82,8 +82,8 @@ export function generateSteps(numCourses: number, prerequisites: number[][]) {
 
   // Log initial state of the queue after population (Breakpoint 7)
   l.simple({ numCourses });
-  l.hashmap("prerequisites", from2dArrayToMap(prerequisites));
-  l.hashmap("graph", from2dArrayToMap(graph));
+  l.hashmap("prerequisites", from2dArrayToMap(prerequisites), { value: -1, color: "neutral" });
+  l.hashmap("graph", from2dArrayToMap(graph), { value: -1, color: "neutral" });
   l.arrayV2({ inDegree: inDegree }, {});
   l.arrayV2({ queue: queue }, {}); // Queue might be populated now
   l.breakpoint(7);
@@ -93,8 +93,8 @@ export function generateSteps(numCourses: number, prerequisites: number[][]) {
     // Log start of while loop iteration (Breakpoint 8)
     l.simple({ numCourses });
     l.group("courses finished", { count });
-    l.hashmap("prerequisites", from2dArrayToMap(prerequisites));
-    l.hashmap("graph", from2dArrayToMap(graph));
+    l.hashmap("prerequisites", from2dArrayToMap(prerequisites), { value: -1, color: "neutral" });
+    l.hashmap("graph", from2dArrayToMap(graph), { value: -1, color: "neutral" });
     l.arrayV2({ inDegree: inDegree }, {});
     l.arrayV2({ queue: queue }, {});
     l.breakpoint(8);
@@ -105,8 +105,8 @@ export function generateSteps(numCourses: number, prerequisites: number[][]) {
     // Log after dequeuing and incrementing count (Breakpoint 9)
     l.simple({ numCourses, current });
     l.group("courses finished", { count });
-    l.hashmap("prerequisites", from2dArrayToMap(prerequisites));
-    l.hashmap("graph", from2dArrayToMap(graph));
+    l.hashmap("prerequisites", from2dArrayToMap(prerequisites), { value: -1, color: "neutral" });
+    l.hashmap("graph", from2dArrayToMap(graph), { value: -1, color: "neutral" });
     l.arrayV2({ inDegree: inDegree }, {});
     l.arrayV2({ queue: queue }, {}); // Queue after shift
     l.breakpoint(9);
@@ -118,7 +118,7 @@ export function generateSteps(numCourses: number, prerequisites: number[][]) {
       // Log before decrementing neighbor inDegree (Breakpoint 10)
       l.simple({ numCourses, current, neighbor });
       l.group("courses finished", { count });
-      l.hashmap("prerequisites", from2dArrayToMap(prerequisites));
+      l.hashmap("prerequisites", from2dArrayToMap(prerequisites), { value: -1, color: "neutral" });
       l.hashmap("graph", from2dArrayToMap(graph), {
         value: current, // Highlight the current course row in the graph
         color: "primary",
@@ -133,7 +133,7 @@ export function generateSteps(numCourses: number, prerequisites: number[][]) {
       // Log after decrementing neighbor inDegree (Breakpoint 11)
       l.simple({ numCourses, current, neighbor });
       l.group("courses finished", { count });
-      l.hashmap("prerequisites", from2dArrayToMap(prerequisites));
+      l.hashmap("prerequisites", from2dArrayToMap(prerequisites), { value: -1, color: "neutral" });
       l.hashmap("graph", from2dArrayToMap(graph), {
         value: current,
         color: "primary",
@@ -147,7 +147,7 @@ export function generateSteps(numCourses: number, prerequisites: number[][]) {
         // Log before adding neighbor to queue (Breakpoint 12)
         l.simple({ numCourses, current, neighbor });
         l.group("courses finished", { count });
-        l.hashmap("prerequisites", from2dArrayToMap(prerequisites));
+        l.hashmap("prerequisites", from2dArrayToMap(prerequisites), { value: -1, color: "neutral" });
         l.hashmap("graph", from2dArrayToMap(graph), {
           value: current,
           color: "primary",
@@ -164,8 +164,8 @@ export function generateSteps(numCourses: number, prerequisites: number[][]) {
     // Log after processing all neighbors of 'current' (Breakpoint 13)
     l.simple({ numCourses, current });
     l.group("courses finished", { count });
-    l.hashmap("prerequisites", from2dArrayToMap(prerequisites));
-    l.hashmap("graph", from2dArrayToMap(graph));
+    l.hashmap("prerequisites", from2dArrayToMap(prerequisites), { value: -1, color: "neutral" });
+    l.hashmap("graph", from2dArrayToMap(graph), { value: -1, color: "neutral" });
      l.arrayV2({ inDegree: inDegree }, {});
      l.arrayV2({ queue: queue }, {}); // Queue might have new elements
     l.breakpoint(13);
@@ -177,8 +177,8 @@ export function generateSteps(numCourses: number, prerequisites: number[][]) {
   l.group("courses finished", { count });
   l.group("result", { allCoursesTaken }); // Log the final boolean result
   l.simple({ result: allCoursesTaken });
-  l.hashmap("prerequisites", from2dArrayToMap(prerequisites));
-  l.hashmap("graph", from2dArrayToMap(graph));
+  l.hashmap("prerequisites", from2dArrayToMap(prerequisites), { value: -1, color: "neutral" });
+  l.hashmap("graph", from2dArrayToMap(graph), { value: -1, color: "neutral" });
    l.arrayV2({ inDegree: inDegree }, {}); // Final state of inDegree
    l.arrayV2({ queue: queue }, {}); // Queue should be empty if successful
   l.breakpoint(14);

--- a/packages/backend/src/problem/free/editDistance/problem.ts
+++ b/packages/backend/src/problem/free/editDistance/problem.ts
@@ -11,6 +11,7 @@ export const problem: Problem<EditDistanceInput, ProblemState> = {
   title,
   emoji: "✍️", // Updated emoji
   id: "editDistance", // Updated id
+  difficulty: "medium",
   tags: ["dynamic programming", "string"],
   func: (input) => generateSteps(...input), // Corrected function assignment
   testcases, // Added testcases property

--- a/packages/backend/src/problem/free/insert-interval/steps.ts
+++ b/packages/backend/src/problem/free/insert-interval/steps.ts
@@ -17,9 +17,9 @@ export function generateSteps(
   const loopMergingGroup = groups.find((g) => g.name === "loop_merging")!.name;
 
   // Log initial state (Breakpoint #1 in code.ts corresponds to this)
-  l.intervals("intervals", intervals, [], inputGroup, 100);
-  l.intervals("newInterval", newInterval, [], inputGroup, 100);
-  l.intervals("result", result, [], resultArrayGroup, 100);
+  l.intervals("intervals", intervals, [], 0, 100);
+  l.intervals("newInterval", [newInterval], [], 0, 100);
+  l.intervals("result", result, [], 0, 100);
   l.simple({ i });
   l.breakpoint(1, "Initial state before processing intervals.");
 
@@ -30,11 +30,11 @@ export function generateSteps(
     i++;
 
     // Log state inside loop 1
-    l.intervals("intervals", intervals, [i - 1], inputGroup, 100); // Highlight the interval just added
-    l.intervals("newInterval", newInterval, [], inputGroup, 100);
-    l.intervals("result", result, [], resultArrayGroup, 100);
+    l.intervals("intervals", intervals, [i - 1], 0, 100); // Highlight the interval just added
+    l.intervals("newInterval", [newInterval], [], 0, 100);
+    l.intervals("result", result, [], 0, 100);
     l.simple({ i });
-    l.intervals("currentInterval", currentInterval, [], loopMergingGroup, 100); // Log the interval just processed
+    l.intervals("currentInterval", [currentInterval], [], 0, 100); // Log the interval just processed
     l.breakpoint(
       2,
       `Adding interval [${currentInterval.join(
@@ -51,11 +51,11 @@ export function generateSteps(
     i++;
 
     // Log state inside loop 2
-    l.intervals("intervals", intervals, [i - 1], inputGroup, 100); // Highlight the interval just merged
-    l.intervals("newInterval", newInterval, [], inputGroup, 100); // Show updated newInterval
-    l.intervals("result", result, [], resultArrayGroup, 100);
+    l.intervals("intervals", intervals, [i - 1], 0, 100); // Highlight the interval just merged
+    l.intervals("newInterval", [newInterval], [], 0, 100); // Show updated newInterval
+    l.intervals("result", result, [], 0, 100);
     l.simple({ i });
-    l.intervals("currentInterval", currentInterval, [], loopMergingGroup, 100); // Log the interval just processed
+    l.intervals("currentInterval", [currentInterval], [], 0, 100); // Log the interval just processed
     l.breakpoint(
       3,
       `Merging interval [${currentInterval.join(
@@ -66,9 +66,9 @@ export function generateSteps(
 
   // Insert the merged newInterval (Breakpoint #4)
   result.push(newInterval);
-  l.intervals("intervals", intervals, [], inputGroup, 100);
-  l.intervals("newInterval", newInterval, [], inputGroup, 100); // Show final merged/original newInterval
-  l.intervals("result", result, [], resultArrayGroup, 100); // Show result with newInterval added
+  l.intervals("intervals", intervals, [], 0, 100);
+  l.intervals("newInterval", [newInterval], [], 0, 100); // Show final merged/original newInterval
+  l.intervals("result", result, [], 0, 100); // Show result with newInterval added
   l.simple({ i });
   l.breakpoint(
     4,
@@ -84,11 +84,11 @@ export function generateSteps(
     i++;
 
     // Log state inside loop 3
-    l.intervals("intervals", intervals, [i - 1], inputGroup, 100); // Highlight the interval just added
-    l.intervals("newInterval", newInterval, [], inputGroup, 100);
-    l.intervals("result", result, [], resultArrayGroup, 100);
+    l.intervals("intervals", intervals, [i - 1], 0, 100); // Highlight the interval just added
+    l.intervals("newInterval", [newInterval], [], 0, 100);
+    l.intervals("result", result, [], 0, 100);
     l.simple({ i });
-    l.intervals("currentInterval", currentInterval, [], loopMergingGroup, 100); // Log the interval just processed
+    l.intervals("currentInterval", [currentInterval], [], 0, 100); // Log the interval just processed
     l.breakpoint(
       5,
       `Adding remaining interval [${currentInterval.join(", ")}].`
@@ -96,9 +96,9 @@ export function generateSteps(
   }
 
   // Final state log (Breakpoint #6)
-  l.intervals("intervals", intervals, [], inputGroup, 100);
-  l.intervals("newInterval", newInterval, [], inputGroup, 100);
-  l.intervals("result", result, [], resultArrayGroup, 100); // Final result array
+  l.intervals("intervals", intervals, [], 0, 100);
+  l.intervals("newInterval", [newInterval], [], 0, 100);
+  l.intervals("result", result, [], 0, 100); // Final result array
   l.simple({ i });
   l.breakpoint(6, "Finished processing all intervals. Returning final result.");
 

--- a/packages/backend/src/problem/free/longestIncreasingSubsequence/steps.ts
+++ b/packages/backend/src/problem/free/longestIncreasingSubsequence/steps.ts
@@ -54,7 +54,7 @@ export function generateSteps(nums: number[]) { // Return type inferred
   // Calculate and log final result
   const maxLength = n > 0 ? Math.max(...dp) : 0; // Use maxLength based on variables.ts, handle empty array case
 
-  l.simple("result", maxLength, { group: "result" }); // Changed label to "result"
+  l.simple({ result: maxLength }); // Changed label to "result"
   l.arrayV2({ dp: dp }); // Use arrayV2, no pointers needed
   l.arrayV2({ nums: nums }); // Use arrayV2, no pointers needed
 


### PR DESCRIPTION
This commit addresses various TypeScript errors identified by `tsc --noEmit`.

Changes include:
- Fixed `Type 'number | undefined' is not assignable to type 'number'` errors in `core/utils.ts` by handling potential undefined values in `addRandomIds`, `asArray`, `asStringArray`, and `asBinary`.
- Addressed `possibly 'undefined'` errors for pointers in `core/utils.ts` by ensuring initialization and adding checks.
- Added missing `difficulty` property to problem definitions in `bestTimeToBuyAndSellStocks/problem.ts` ("easy") and `editDistance/problem.ts` ("medium").
- Added missing `: number` type annotation to the parameter in `climbingStairs/code/typescript.ts`.
- Fixed `Argument of type '{}' is not assignable to parameter of type 'HashHighlight'` errors in `contains-duplicate/steps.ts` by providing a default highlight object to `logger.hashset`.
- Fixed `Expected 3 arguments, but got 2` errors in `course-schedule/steps.ts` by adding a default highlight object to `l.hashmap` calls.
- Fixed `Argument of type 'string' is not assignable to parameter of type 'number'` and other argument mismatches in `insert-interval/steps.ts` for `l.intervals` calls by correcting argument types and values (using 0/100 for min/max and wrapping single intervals in arrays).
- Fixed `Expected 1 arguments, but got 3` error in `longestIncreasingSubsequence/steps.ts` by correcting the `l.simple` call format.

Verification with `tsc --noEmit` could not be performed due to execution environment limitations.