### PR TITLE
feat(problem): add comprehensive tests for course-schedule

### DIFF
--- a/packages/backend/src/problem/free/course-schedule/testcase.ts
+++ b/packages/backend/src/problem/free/course-schedule/testcase.ts
@@ -1,10 +1,10 @@
 import { TestCase } from "algo-lens-core";
 import { CourseScheduleInput } from "./types";
-// Removed import for CourseScheduleInput
+// Removed import for CourseScheduleInput - Keeping this comment as it was in the original
 
-// Reverted TestCase signature to use tuple input type
+// Reverted TestCase signature to use tuple input type - Keeping this comment as it was in the original
 export const testcases: TestCase<CourseScheduleInput, boolean>[] = [
-  // Test case 1
+  // === Existing Test Cases (Descriptions updated for clarity) ===
   {
     input: [
       2,
@@ -14,10 +14,8 @@ export const testcases: TestCase<CourseScheduleInput, boolean>[] = [
       ],
     ],
     expected: false,
-    description: "Test case 1: The prerequisites are correctly represented.",
+    description: "Test Case 1: Direct cycle (0 -> 1, 1 -> 0)",
   },
-
-  // Test case 2
   {
     input: [
       2,
@@ -27,11 +25,8 @@ export const testcases: TestCase<CourseScheduleInput, boolean>[] = [
       ],
     ],
     expected: false,
-    description:
-      "Test case 2: There are two courses that have a prerequisite relationship, but one course cannot be taken before the other.",
+    description: "Test Case 2: Self-loop cycle (1 -> 1)",
   },
-
-  // Test case 3
   {
     input: [
       3,
@@ -42,11 +37,8 @@ export const testcases: TestCase<CourseScheduleInput, boolean>[] = [
       ],
     ],
     expected: true,
-    description:
-      "Test case 3: The prerequisites are correctly represented and all courses can be taken.",
+    description: "Test Case 3: Valid DAG (0 -> 1, 2 -> 1, 0 -> 2)",
   },
-
-  // Test case 4
   {
     input: [
       4,
@@ -57,7 +49,93 @@ export const testcases: TestCase<CourseScheduleInput, boolean>[] = [
       ],
     ],
     expected: true,
-    description:
-      "Test case 4: Linear dependency chain, all courses can be taken.",
+    description: "Test Case 4: Linear dependency chain (0 -> 1 -> 2 -> 3)",
   },
+
+  // === New Test Cases ===
+
+  // Edge Cases
+  {
+    input: [0, []],
+    expected: true,
+    description: "Test Case 5: Edge case - 0 courses",
+  },
+  {
+    input: [1, []],
+    expected: true,
+    description: "Test Case 6: Edge case - 1 course, no prerequisites",
+  },
+  {
+    input: [3, []],
+    expected: true,
+    description: "Test Case 7: No prerequisites",
+  },
+
+  // Disconnected Components
+  {
+    input: [
+      5,
+      [
+        [1, 0], // Component 1: 0 -> 1
+        [3, 2], // Component 2: 2 -> 3
+        // Course 4 is isolated
+      ],
+    ],
+    expected: true,
+    description: "Test Case 8: Disconnected components",
+  },
+
+  // Complex Cycles
+  {
+    input: [
+      3,
+      [
+        [1, 0],
+        [2, 1],
+        [0, 2], // Cycle: 0 -> 1 -> 2 -> 0
+      ],
+    ],
+    expected: false,
+    description: "Test Case 9: Longer cycle (3 nodes)",
+  },
+  {
+    input: [
+      4,
+      [
+        [1, 0],
+        [0, 1], // Cycle 1: 0 -> 1 -> 0
+        [3, 2],
+        [2, 3], // Cycle 2: 2 -> 3 -> 2
+      ],
+    ],
+    expected: false,
+    description: "Test Case 10: Multiple cycles in disconnected components",
+  },
+
+  // Larger Valid DAG
+  {
+    input: [
+      6,
+      [
+        [1, 0],
+        [2, 0],
+        [3, 1],
+        [4, 1],
+        [5, 2],
+        [5, 4], // More complex DAG
+      ],
+    ],
+    expected: true,
+    description: "Test Case 11: Larger valid DAG",
+  },
+  {
+    input: [ // Added another complex DAG case
+      7,
+      [
+        [1,0], [2,0], [3,1], [3,2], [4,3], [5,3], [6,4], [6,5]
+      ]
+    ],
+    expected: true,
+    description: "Test Case 12: Complex DAG with multiple paths"
+  }
 ];


### PR DESCRIPTION
The existing implementation for course-schedule (canFinish) appears correct, using Kahn's algorithm.

However, the test suite lacked coverage for edge cases and more complex scenarios. This change enhances the test suite in `testcase.ts` by adding tests for:

- 0 courses
- 1 course
- No prerequisites
- Disconnected graph components
- Complex cycles
- Larger valid DAGs

This provides greater confidence in the algorithm's correctness across various inputs, even though automated test execution was unavailable.