### PR TITLE
Add testcase dropdown to frontend

### DIFF
--- a/packages/frontend/src/api.ts
+++ b/packages/frontend/src/api.ts
@@ -16,13 +16,32 @@ export async function getProblem(id: string) {
   return result.json();
 }
 
-export async function getProblemState(id: string, step: number) {
-  const result = await be.get<ProblemState>(`problem/${id}/state/${step}`);
+export async function getProblemState(id: string, step: number, testcaseIndex?: number) {
+  let url = `problem/${id}/state/${step}`;
+  if (testcaseIndex !== undefined) {
+    url += `?testcaseIndex=${testcaseIndex}`;
+  }
+  const result = await be.get<ProblemState>(url);
   return result.json();
 }
 
-export async function getProblemSize(id:string){
-  const result = await be.get<{size:number}>(`problem/${id}/size`);
+export async function getProblemSize(id: string, testcaseIndex?: number) {
+  let url = `problem/${id}/size`;
+  if (testcaseIndex !== undefined) {
+    url += `?testcaseIndex=${testcaseIndex}`;
+  }
+  const result = await be.get<{size:number}>(url);
   const json = await result.json();
   return json.size;
+}
+
+export async function setTestcaseIndex(id: string, index: number) {
+  const result = await be.get<{success: boolean, testcaseIndex: number}>(`problem/${id}/testcase/${index}`);
+  return result.json();
+}
+
+export async function getCurrentTestcaseIndex(id: string) {
+  const result = await be.get<{testcaseIndex: number}>(`problem/${id}/testcase`);
+  const json = await result.json();
+  return json.testcaseIndex;
 }

--- a/packages/frontend/src/atom.ts
+++ b/packages/frontend/src/atom.ts
@@ -7,6 +7,8 @@ export const problemAtom = atom<Problem<any,any> | null>(null);
 
 export const stepAtom = atom<number>(1);
 
-export const maxStepAtom = atom<number>(100)
+export const maxStepAtom = atom<number>(100);
 
-export const problemStateAtom = atom<ProblemState | null>(null);``
+export const testcaseIndexAtom = atom<number>(0);
+
+export const problemStateAtom = atom<ProblemState | null>(null);

--- a/packages/frontend/src/components/ProblemVisualizer.tsx
+++ b/packages/frontend/src/components/ProblemVisualizer.tsx
@@ -5,20 +5,20 @@ import DisplayState from "./DisplayState";
 import CodePreview from "./CodePreview";
 import Slider from "./Slider";
 import { useAtom } from "jotai";
-import { maxStepAtom, problemAtom, problemStateAtom, stepAtom } from "../atom";
-import { getProblem, getProblemSize } from "../api";
+import { maxStepAtom, problemAtom, problemStateAtom, stepAtom, testcaseIndexAtom } from "../atom";
+import { getProblem, getProblemSize, setTestcaseIndex } from "../api";
 
 function ProblemVisualizer() {
   const [state] = useAtom(problemStateAtom);
   const [problem, setProblem] = useAtom(problemAtom);
-
   const [step, setStep] = useAtom(stepAtom);
   const [maxStep, setMaxStep] = useAtom(maxStepAtom);
+  const [testcaseIndex, setTestcaseIndexState] = useAtom(testcaseIndexAtom);
 
   if (!state || !problem) {
     return null;
   }
-  const { title, code, id } = problem;
+  const { title, code, id, testcases } = problem;
 
   const breakpointToLineMap = new Map<number, number>();
   const lines = code!.split("\n");
@@ -46,10 +46,39 @@ function ProblemVisualizer() {
     copy(code!);
     alert("Code copied to clipboard!");
   };
+  
+  const handleTestcaseChange = async (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const newIndex = parseInt(e.target.value);
+    try {
+      await setTestcaseIndex(problem.id!, newIndex);
+      setTestcaseIndexState(newIndex);
+      // Reset step to 1 when changing testcase
+      setStep(1);
+      // Update max step for the new testcase
+      const size = await getProblemSize(problem.id!, newIndex);
+      setMaxStep(size);
+    } catch (error) {
+      console.error("Failed to set testcase index:", error);
+    }
+  };
 
   useEffect(() => {
-    getProblemSize(problem.id!).then((size) => setMaxStep(size));
-  }, [problem]);
+    getProblemSize(problem.id!, testcaseIndex).then((size) => setMaxStep(size));
+  }, [problem, testcaseIndex]);
+
+  // Format testcase for display
+  const formatTestcase = (testcase: any) => {
+    if (!testcase) return "N/A";
+    
+    try {
+      if (typeof testcase === 'object') {
+        return JSON.stringify(testcase);
+      }
+      return String(testcase);
+    } catch (e) {
+      return "Error formatting testcase";
+    }
+  };
 
   return (
     <div className="mx-8 my-8 flex-1">
@@ -59,7 +88,7 @@ function ProblemVisualizer() {
           <h2 className="font-display text-3xl pl-2">{title}</h2>
           <a
             href={`https://leetcode.com/problems/${id}/description/`}
-            className="link  tooltip tooltip-right"
+            className="link tooltip tooltip-right"
             data-tip="Go to Leetcode"
             target="_blank"
             rel="noopener noreferrer"
@@ -76,12 +105,34 @@ function ProblemVisualizer() {
           >
             <i className="fas fa-copy"></i>
           </button>
+          
+          {/* Testcase Dropdown */}
+          {testcases && testcases.length > 0 && (
+            <div className="flex items-center gap-2">
+              <label htmlFor="testcase-select" className="text-sm font-medium">
+                Testcase:
+              </label>
+              <select
+                id="testcase-select"
+                className="select select-bordered select-sm"
+                value={testcaseIndex}
+                onChange={handleTestcaseChange}
+              >
+                {testcases.map((testcase, index) => (
+                  <option key={index} value={index}>
+                    {index + 1}: {formatTestcase(testcase.input).substring(0, 30)}
+                    {formatTestcase(testcase.input).length > 30 ? "..." : ""}
+                  </option>
+                ))}
+              </select>
+            </div>
+          )}
         </div>
-        <div className="flex flex-col lg:flex-row  lg:gap-20">
-          <div className="flex-1 p-2  lg:w-1/2">
+        <div className="flex flex-col lg:flex-row lg:gap-20">
+          <div className="flex-1 p-2 lg:w-1/2">
             <CodePreview code={code} highlightLineIndex={line} />
           </div>
-          <div className="lg:pl-6 flex-1 lg:w-1/2  lg:p-2 space-y-4">
+          <div className="lg:pl-6 flex-1 lg:w-1/2 lg:p-2 space-y-4">
             <div className="flex items-center gap-6">
               <Slider
                 min={1}

--- a/packages/frontend/src/pages/problem/ProblemView.tsx
+++ b/packages/frontend/src/pages/problem/ProblemView.tsx
@@ -1,29 +1,31 @@
 import { useAtom } from "jotai";
 import ProblemVisualizer from "../../components/ProblemVisualizer";
-import { maxStepAtom, problemAtom, problemStateAtom, stepAtom } from "../../atom";
-import { getProblem, getProblemState } from "../../api";
+import { maxStepAtom, problemAtom, problemStateAtom, stepAtom, testcaseIndexAtom } from "../../atom";
+import { getProblem, getProblemState, getCurrentTestcaseIndex } from "../../api";
 import { useEffect } from "react";
 
 export function useProblemState() {
   const [problem, setProblem] = useAtom(problemAtom);
   const [step, setStep] = useAtom(stepAtom);
   const [state, setState] = useAtom(problemStateAtom);
+  const [testcaseIndex] = useAtom(testcaseIndexAtom);
 
   useEffect(() => {
     if (problem && step) {
       const fetchState = async () => {
-        const s = await getProblemState(problem.id!, step);
+        const s = await getProblemState(problem.id!, step, testcaseIndex);
         setState(s);
       };
       fetchState();
     }
-  }, [problem, step]);
+  }, [problem, step, testcaseIndex]);
 
   return state;
 }
 
 export default function ProblemView() {
   const [problem, setProblem] = useAtom(problemAtom);
+  const [, setTestcaseIndex] = useAtom(testcaseIndexAtom);
   const state = useProblemState();
 
   async function init() {
@@ -37,12 +39,23 @@ export default function ProblemView() {
     console.log("init problem visualizer with id", id);
     //fetch problem details from backend
     const p = await getProblem(id!);
+    
+    // Get current testcase index
+    try {
+      const currentIndex = await getCurrentTestcaseIndex(id!);
+      setTestcaseIndex(currentIndex);
+    } catch (error) {
+      console.error("Failed to get current testcase index:", error);
+      setTestcaseIndex(0);
+    }
 
     console.log("init problem visualizer with problem", p);
     setProblem(p);
   }
+  
   useEffect(() => {
     init();
   }, []);
+  
   return <div>{problem && state && <ProblemVisualizer />}</div>;
 }


### PR DESCRIPTION
This PR adds a dropdown to select different testcases for a problem in the visualization tool.

## Changes

### Backend
- Modified `/problem/:id` endpoint to include testcases in the response
- Added new endpoints for getting and setting the testcase index
- Updated the ProblemStateCache to handle different testcases
- Modified the state and size endpoints to accept a testcaseIndex parameter

### Frontend
- Added a testcaseIndexAtom to the state management
- Updated the API functions to support testcase selection
- Modified the ProblemView component to fetch and use the selected testcase
- Added a dropdown to the ProblemVisualizer component to select testcases

## How to Test
1. Open a problem with multiple testcases
2. Use the dropdown to select different testcases
3. Verify that the visualization updates correctly when changing testcases