### PR TITLE
feat: Implement frontend test case selection

### DIFF
--- a/packages/algo-lens-core/types/core.ts
+++ b/packages/algo-lens-core/types/core.ts
@@ -7,6 +7,7 @@ export interface TestCase<Input, State> {
   input: Input;
   expected: any;
   description?: string;
+  isDefault?: boolean;
 }
 
 /** Defines a generic interface for a problem, parameterized by Input and State types. */

--- a/packages/backend/src/index.test.ts
+++ b/packages/backend/src/index.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect } from "bun:test";
+import app from "./index"; // Import the default export which contains app.fetch
+import { Problem } from "algo-lens-core"; // Import Problem type if needed for detailed checks
+
+// Helper to make requests and parse JSON
+const makeRequest = async (path: string) => {
+  // Using a base URL, although it's not strictly necessary for app.fetch
+  const req = new Request(`http://localhost${path}`);
+  const res = await app.fetch(req);
+  return {
+    status: res.status,
+    body: await res.json().catch(() => null), // Gracefully handle non-JSON responses
+  };
+};
+
+describe("Backend API Tests", () => {
+
+  const validProblemId = "two-sum";
+  const invalidProblemId = "invalid-id";
+  const defaultTestCaseIndex = 0; // two-sum's first test case is default
+  const secondTestCaseIndex = 1;
+
+  // --- GET /problem/:id Tests ---
+  describe("GET /problem/:id", () => {
+    it("should return 200 and problem details (excluding testcases) for a valid ID", async () => {
+      const { status, body } = await makeRequest(`/problem/${validProblemId}`);
+      expect(status).toBe(200);
+      expect(body).toBeDefined();
+      expect(body.id).toBe(validProblemId);
+      expect(body.title).toBeDefined();
+      // Verify the structure based on the `pick` function in index.ts
+      expect(body.difficulty).toBeDefined();
+      expect(body.code).toBeDefined();
+      expect(body.url).toBeDefined(); // Added check for url
+      expect(body.tags).toBeArray(); // Added check for tags
+      expect(body.metadata).toBeDefined();
+      // Assert that testcases are NOT included in the response due to `pick`
+      expect(body.testcases).toBeUndefined();
+    });
+
+    it("should return 404 for an invalid ID", async () => {
+      const { status, body } = await makeRequest(`/problem/${invalidProblemId}`);
+      expect(status).toBe(404);
+      expect(body.error).toBe("Problem not found");
+    });
+  });
+
+  // --- GET /problem/:id/size Tests ---
+  describe("GET /problem/:id/size", () => {
+    it("should return 200 and size for the default test case when no index is specified", async () => {
+      const { status, body } = await makeRequest(`/problem/${validProblemId}/size`);
+      expect(status).toBe(200);
+      expect(body.size).toBeNumber();
+      // two-sum default test case ([2, 7, 11, 15], 9) has 7 steps.
+      expect(body.size).toBe(7);
+    });
+
+    it("should return 200 and size for the specified test case index", async () => {
+      const { status, body } = await makeRequest(`/problem/${validProblemId}/size?testCaseIndex=${secondTestCaseIndex}`);
+      expect(status).toBe(200);
+      expect(body.size).toBeNumber();
+      // two-sum second test case ([3, 2, 4], 6) has 7 steps.
+      expect(body.size).toBe(7);
+    });
+
+     it("should return 500 for an out-of-bounds test case index", async () => {
+       const outOfBoundsIndex = 100;
+       const { status, body } = await makeRequest(`/problem/${validProblemId}/size?testCaseIndex=${outOfBoundsIndex}`);
+       // The backend's stateCache.getSize -> cacheProblemTestCase throws an error for invalid index, caught by the route handler
+       expect(status).toBe(500); // Error during size calculation leads to 500
+       expect(body.error).toContain("Internal server error while calculating size"); // Check generic error from catch block
+     });
+
+     it("should return 400 for an invalid (non-numeric) test case index query", async () => {
+       const { status, body } = await makeRequest(`/problem/${validProblemId}/size?testCaseIndex=abc`);
+       expect(status).toBe(400);
+       expect(body.error).toContain("Invalid testCaseIndex query parameter");
+     });
+
+
+    it("should return 404 for an invalid problem ID", async () => {
+      const { status, body } = await makeRequest(`/problem/${invalidProblemId}/size`);
+      expect(status).toBe(404);
+      expect(body.error).toBe(`Problem not found: ${invalidProblemId}`);
+    });
+  });
+
+  // --- GET /problem/:id/testcase/:testCaseIndex/state/:step Tests ---
+  describe("GET /problem/:id/testcase/:testCaseIndex/state/:step", () => {
+    const validStep = 1;
+    const outOfBoundsStep = 999; // Assume less than 999 steps
+
+    it("should return 200 and state for valid id, testCaseIndex=0, and step=1", async () => {
+      const { status, body } = await makeRequest(`/problem/${validProblemId}/testcase/${defaultTestCaseIndex}/state/${validStep}`);
+      expect(status).toBe(200);
+      expect(body).toBeDefined();
+      expect(body.variables).toBeArray();
+      expect(body.breakpoint).toBeNumber();
+    });
+
+    it("should return 200 and state for valid id, testCaseIndex=1, and step=1", async () => {
+       const { status, body } = await makeRequest(`/problem/${validProblemId}/testcase/${secondTestCaseIndex}/state/${validStep}`);
+       expect(status).toBe(200);
+       expect(body).toBeDefined();
+       expect(body.variables).toBeArray();
+       expect(body.breakpoint).toBeNumber();
+       // You could fetch state for index 0, step 1 and compare if needed
+    });
+
+
+    it("should return 404 for an out-of-bounds step", async () => {
+      // Fetch the actual size first to determine a reliable out-of-bounds step
+      const sizeRes = await makeRequest(`/problem/${validProblemId}/size?testCaseIndex=${defaultTestCaseIndex}`);
+      const size = sizeRes.body.size;
+      const invalidStep = size + 1;
+
+      const { status, body } = await makeRequest(`/problem/${validProblemId}/testcase/${defaultTestCaseIndex}/state/${invalidStep}`);
+      expect(status).toBe(404);
+      expect(body.error).toContain(`Step ${invalidStep} out of bounds`);
+    });
+
+     it("should return 400 for an out-of-bounds test case index", async () => {
+       const outOfBoundsIndex = 100;
+      const { status, body } = await makeRequest(`/problem/${validProblemId}/testcase/${outOfBoundsIndex}/state/${validStep}`);
+      expect(status).toBe(400);
+       expect(body.error).toContain(`testCaseIndex ${outOfBoundsIndex} out of bounds`);
+    });
+
+     it("should return 400 for an invalid (non-numeric) test case index", async () => {
+       const { status, body } = await makeRequest(`/problem/${validProblemId}/testcase/abc/state/${validStep}`);
+       expect(status).toBe(400);
+       expect(body.error).toBe("Invalid testCaseIndex");
+     });
+
+      it("should return 400 for an invalid (non-numeric) step", async () => {
+       const { status, body } = await makeRequest(`/problem/${validProblemId}/testcase/${defaultTestCaseIndex}/state/xyz`);
+       expect(status).toBe(400);
+       expect(body.error).toBe("Invalid step number");
+     });
+
+       it("should return 400 for step 0", async () => {
+       const { status, body } = await makeRequest(`/problem/${validProblemId}/testcase/${defaultTestCaseIndex}/state/0`);
+       expect(status).toBe(400);
+       expect(body.error).toBe("Invalid step number");
+     });
+
+
+    it("should return 404 for an invalid problem ID", async () => {
+      const { status, body } = await makeRequest(`/problem/${invalidProblemId}/testcase/${defaultTestCaseIndex}/state/${validStep}`);
+      expect(status).toBe(404);
+      expect(body.error).toBe(`Problem not found: ${invalidProblemId}`);
+    });
+  });
+});

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -65,66 +65,188 @@ app.get("/problem/:id", async (c) => {
 });
 
 class ProblemStateCache {
-  private cache = new Map<string, ProblemState>();
+  // Cache structure: Map<problemId, Map<testCaseIndex, Map<step, ProblemState>>>
+  private cache = new Map<string, Map<number, Map<number, ProblemState>>>();
+  // Size cache structure: Map<problemId, Map<testCaseIndex, size>>
+  private size = new Map<string, Map<number, number>>();
 
-  private size = new Map<string, number>();
-
-  getKey(problem: Problem<any, any>, step: number): string {
-    return problem.id + "-" + step;
+  // Generates a cache key for a specific step of a specific test case for a problem.
+  getKey(problemId: string, testCaseIndex: number, step: number): string {
+    return `${problemId}-${testCaseIndex}-${step}`;
   }
 
-  get(problem: Problem<any, any>, step: number): ProblemState | undefined {
-    const key = this.getKey(problem, step);
-    const cached = this.cache.get(key);
-    if (cached) {
-      return cached;
+  // Retrieves a state from the cache or computes and caches it if not present.
+  get(problem: Problem<any, any>, testCaseIndex: number, step: number): ProblemState | undefined {
+    const problemCache = this.cache.get(problem.id);
+    const testCaseCache = problemCache?.get(testCaseIndex);
+    const cachedState = testCaseCache?.get(step);
+
+    if (cachedState) {
+      return cachedState;
     }
-    this.cacheProblem(problem);
-    return this.cache.get(key);
+
+    // If state is not cached, compute and cache states for the entire test case.
+    this.cacheProblemTestCase(problem, testCaseIndex);
+
+    // Attempt to retrieve the state again after caching.
+    return this.cache.get(problem.id)?.get(testCaseIndex)?.get(step);
   }
 
-  private cacheProblem(problem: Problem<any, any>) {
-    const { testcases } = problem;
-    if (!testcases) {
-      throw new Error("no testcases found for problem: " + problem.id!);
+  // Computes and caches all states for a given test case of a problem.
+  private cacheProblemTestCase(problem: Problem<any, any>, testCaseIndex: number) {
+    const { testcases, func, id: problemId } = problem;
+    if (!testcases || testcases.length === 0) {
+      // It's valid for a problem to initially have no test cases, log a warning.
+      console.warn(`No testcases found for problem: ${problemId}`);
+      // Ensure cache entries exist to prevent errors later
+      if (!this.cache.has(problemId)) this.cache.set(problemId, new Map());
+      if (!this.size.has(problemId)) this.size.set(problemId, new Map());
+       if (!this.cache.get(problemId)!.has(testCaseIndex)) this.cache.get(problemId)!.set(testCaseIndex, new Map());
+       if (!this.size.get(problemId)!.has(testCaseIndex)) this.size.get(problemId)!.set(testCaseIndex, 0); // Size is 0
+      return; // Nothing to cache
     }
-    if (testcases.length === 0) {
-      throw new Error("no testcases found for problem: " + problem.id!);
+    if (testCaseIndex < 0 || testCaseIndex >= testcases.length) {
+      throw new Error(`Invalid testCaseIndex ${testCaseIndex} for problem ${problemId} with ${testcases.length} testcases.`);
     }
-    const testcase = testcases[2].input;
-    console.log("testcase: ", testcase);
-    const states = problem.func(testcase);
-    for (let i = 0; i < states.length; i++) {
-      const state = states[i];
-      const key2 = this.getKey(problem, i + 1);
-      this.cache.set(key2, state);
+
+    const testcase = testcases[testCaseIndex];
+    if (!testcase || testcase.input === undefined) {
+       // Log error instead of throwing, allows API to return 404 or similar
+       console.error(`Test case or test case input is undefined at index ${testCaseIndex} for problem ${problemId}`);
+       // Set size to 0 for this test case index to avoid repeated calculation attempts
+        if (!this.size.has(problemId)) this.size.set(problemId, new Map());
+        this.size.get(problemId)!.set(testCaseIndex, 0);
+       return; // Cannot generate states
     }
-    this.size.set(problem.id!, states.length);
+
+    console.log(`Caching states for problem ${problemId}, testCaseIndex ${testCaseIndex}`);
+    let states: ProblemState[] = [];
+    try {
+        states = func(testcase.input);
+    } catch (error: any) {
+        console.error(`Error executing problem function for ${problemId}, testCase ${testCaseIndex}: ${error.message}`);
+        // Set size to 0 and return to prevent caching partial/incorrect data
+        if (!this.size.has(problemId)) this.size.set(problemId, new Map());
+        this.size.get(problemId)!.set(testCaseIndex, 0);
+        return;
+    }
+
+
+    if (!this.cache.has(problemId)) {
+      this.cache.set(problemId, new Map());
+    }
+    const problemCache = this.cache.get(problemId)!;
+
+    if (!problemCache.has(testCaseIndex)) {
+        problemCache.set(testCaseIndex, new Map());
+    }
+    const testCaseCache = problemCache.get(testCaseIndex)!;
+    testCaseCache.clear(); // Clear previous states if recaching
+
+    states.forEach((state, index) => {
+      testCaseCache.set(index + 1, state); // Steps are 1-based
+    });
+
+    // Cache the size
+    if (!this.size.has(problemId)) {
+      this.size.set(problemId, new Map());
+    }
+    this.size.get(problemId)!.set(testCaseIndex, states.length);
   }
 
-  getSize(problem: Problem<any, any>): number | undefined {
-    const size = this.size.get(problem.id!);
-    if (!size) {
-      this.cacheProblem(problem);
+
+  // Retrieves the size (number of steps) for a specific test case of a problem.
+  getSize(problem: Problem<any, any>, testCaseIndex: number): number | undefined {
+     // Validate index
+     if (!problem.testcases || testCaseIndex < 0 || testCaseIndex >= problem.testcases.length) {
+          console.warn(`getSize called with invalid index ${testCaseIndex} for problem ${problem.id}`);
+          return undefined; // Or 0, depending on desired behavior for invalid index
+     }
+
+     const problemSizeCache = this.size.get(problem.id);
+     const size = problemSizeCache?.get(testCaseIndex);
+
+     if (size === undefined) {
+       // If size is not cached, compute and cache the states (which also caches size).
+       console.log(`Size not cached for ${problem.id}, testCase ${testCaseIndex}. Caching now.`);
+       this.cacheProblemTestCase(problem, testCaseIndex);
+       // Attempt to retrieve the size again.
+       return this.size.get(problem.id)?.get(testCaseIndex);
+     }
+     return size;
+  }
+
+  // Retrieves the size for the default test case of a problem.
+  getDefaultSize(problem: Problem<any, any>): number | undefined {
+    if (!problem.testcases || problem.testcases.length === 0) {
+        console.warn(`Problem ${problem.id} has no test cases.`);
+        return 0; // No test cases means size 0
     }
-    return this.size.get(problem.id!);
+
+    let defaultTestCaseIndex = problem.testcases.findIndex(tc => tc.isDefault);
+    // Use index 0 if no default is explicitly set
+    const indexToUse = defaultTestCaseIndex !== -1 ? defaultTestCaseIndex : 0;
+
+    // Ensure the index is valid (it should be, given the checks above, but belt-and-suspenders)
+    if (indexToUse < 0 || indexToUse >= problem.testcases.length) {
+        console.error(`Calculated default index ${indexToUse} is out of bounds for problem ${problem.id}. Using 0.`);
+        // Fallback to 0 if the array is somehow empty despite earlier check
+        return this.getSize(problem, 0);
+    }
+
+    return this.getSize(problem, indexToUse);
   }
 }
 
 const stateCache = new ProblemStateCache();
-app.get("/problem/:problemId/state/:step", async (c) => {
+// Updated route: /problem/:problemId/testcase/:testCaseIndex/state/:step
+app.get("/problem/:problemId/testcase/:testCaseIndex/state/:step", async (c) => {
   const problemId = c.req.param("problemId");
+  const testCaseIndex = parseInt(c.req.param("testCaseIndex"));
   const step = parseInt(c.req.param("step"));
+
+  if (isNaN(testCaseIndex) || testCaseIndex < 0) {
+    return c.json({ error: "Invalid testCaseIndex" }, 400);
+  }
+  if (isNaN(step) || step <= 0) { // Steps are 1-based
+    return c.json({ error: "Invalid step number" }, 400);
+  }
 
   const problem = await getProblemById(problemId!);
   if (!problem) {
-    throw new Error(`Problem not found: ${problemId} `);
+    return c.json({ error: `Problem not found: ${problemId}` }, 404);
   }
 
-  const state = stateCache.get(problem!, step);
+   // Check if testcases array exists and is not empty
+  if (!problem.testcases || problem.testcases.length === 0) {
+    return c.json({ error: `No test cases available for problem ${problemId}` }, 404);
+  }
 
-  const preserialized = preserialize(state!);
-  return c.json(preserialized);
+
+  if (testCaseIndex >= problem.testcases.length) {
+     return c.json({ error: `testCaseIndex ${testCaseIndex} out of bounds for problem ${problemId}` }, 400);
+  }
+
+  try {
+    const state = stateCache.get(problem, testCaseIndex, step);
+    if (!state) {
+      // Check if the step is simply out of bounds vs. an error during caching
+       const size = stateCache.getSize(problem, testCaseIndex);
+       if (size !== undefined && step > size) {
+            return c.json({ error: `Step ${step} out of bounds for test case ${testCaseIndex} (size: ${size})` }, 404);
+       } else {
+           // Could indicate an issue during caching or invalid test case input
+           console.error(`State not found for problem ${problemId}, testcase ${testCaseIndex}, step ${step}, but size is ${size}. Potential caching issue.`);
+           return c.json({ error: `State not found for step ${step} in test case ${testCaseIndex}` }, 404); // Keep 404, but log potential issue
+       }
+    }
+    const preserialized = preserialize(state);
+    return c.json(preserialized);
+  } catch (error: any) {
+     console.error(`Error fetching state for problem ${problemId}, testcase ${testCaseIndex}, step ${step}: ${error.message}`);
+     // Return a generic server error
+     return c.json({ error: "Internal server error while fetching state" }, 500);
+  }
 });
 
 function preserialize(state: ProblemState): any {
@@ -149,10 +271,45 @@ app.get("/problem/:problemId/size", async (c) => {
   const problemId = c.req.param("problemId");
 
   const problem = await getProblemById(problemId!);
+  if (!problem) {
+     return c.json({ error: `Problem not found: ${problemId}` }, 404);
+  }
 
-  const size = stateCache.getSize(problem!);
+  try {
+    const testCaseIndexQuery = c.req.query("testCaseIndex");
+    let size: number | undefined;
 
-  return c.json({ size });
+    if (testCaseIndexQuery !== undefined) {
+      const testCaseIndex = parseInt(testCaseIndexQuery);
+      if (!isNaN(testCaseIndex) && testCaseIndex >= 0) {
+        // If a valid testCaseIndex is provided, get the size for that specific index
+        size = stateCache.getSize(problem, testCaseIndex);
+        if (size === undefined) {
+           console.error(`Could not determine size for problem ${problemId}, testCaseIndex ${testCaseIndex}.`);
+           // Explicitly return 500 if getSize fails for a specific index
+           return c.json({ error: `Could not determine size for test case index ${testCaseIndex}` }, 500);
+        }
+      } else {
+         // Invalid testCaseIndex query param
+         return c.json({ error: `Invalid testCaseIndex query parameter: ${testCaseIndexQuery}` }, 400);
+      }
+    } else {
+      // If no testCaseIndex is provided, get the size for the default test case
+      size = stateCache.getDefaultSize(problem);
+      if (size === undefined) {
+         console.error(`Could not determine default size for problem ${problemId}.`);
+          // Explicitly return 500 if getDefaultSize fails
+        return c.json({ error: "Could not determine size for the default test case" }, 500); // Keep 500 for default case failure
+      }
+    }
+
+    // If size is determined successfully (either specific or default)
+    return c.json({ size });
+  } catch (error: any) {
+     console.error(`Error getting default size for problem ${problemId}: ${error.message}`);
+     return c.json({ error: "Internal server error while calculating size" }, 500);
+  }
+
 });
 
 export default {

--- a/packages/backend/src/problem/free/3sum/testcase.ts
+++ b/packages/backend/src/problem/free/3sum/testcase.ts
@@ -8,6 +8,7 @@ export const testcases: TestCase<number[], number[][]>[] = [
       [-1, -1, 2],
       [-1, 0, 1],
     ],
+    isDefault: true,
   },
   {
     input: [0, 1, 1],

--- a/packages/backend/src/problem/free/merge-intervals/testcase.ts
+++ b/packages/backend/src/problem/free/merge-intervals/testcase.ts
@@ -25,6 +25,7 @@ export const testcases: TestCase<MergeIntervalsInput, number[][]>[] = [
       [8, 10],
       [15, 18],
     ],
+    isDefault: true,
     expected: [
       [1, 6],
       [8, 10],

--- a/packages/backend/src/problem/free/two-sum/testcase.ts
+++ b/packages/backend/src/problem/free/two-sum/testcase.ts
@@ -2,7 +2,7 @@ import { ProblemState, TestCase } from "algo-lens-core";
 import { TwoSumInput } from "./types";
 
 export const testcases: TestCase<TwoSumInput, ProblemState>[] = [
-  { input: [[2, 7, 11, 15], 9], expected: [0, 1] },
+  { input: [[2, 7, 11, 15], 9], expected: [0, 1], isDefault: true },
   { input: [[3, 2, 4], 6], expected: [1, 2] },
   { input: [[3, 3], 6], expected: [0, 1] },
   { input: [[-1, 0], -1], expected: [0, 1] },

--- a/packages/frontend/src/api.ts
+++ b/packages/frontend/src/api.ts
@@ -16,8 +16,9 @@ export async function getProblem(id: string) {
   return result.json();
 }
 
-export async function getProblemState(id: string, step: number) {
-  const result = await be.get<ProblemState>(`problem/${id}/state/${step}`);
+// Updated function signature and API endpoint URL
+export async function getProblemState(id: string, testCaseIndex: number, step: number) {
+  const result = await be.get<ProblemState>(`problem/${id}/testcase/${testCaseIndex}/state/${step}`);
   return result.json();
 }
 

--- a/packages/frontend/src/atom.ts
+++ b/packages/frontend/src/atom.ts
@@ -5,7 +5,13 @@ export const problemsAtom = atom<Problem<any,any>[]>([]);
 
 export const problemAtom = atom<Problem<any,any> | null>(null);
 
+// Atom to store the index of the currently selected test case.
+export const selectedTestCaseIndexAtom = atom<number>(0);
+
 export const stepAtom = atom<number>(1);
+
+// Atom to store the index of the currently selected test case.
+export const selectedTestCaseIndexAtom = atom<number>(0);
 
 export const maxStepAtom = atom<number>(100)
 

--- a/packages/frontend/src/components/ProblemVisualizer.tsx
+++ b/packages/frontend/src/components/ProblemVisualizer.tsx
@@ -3,25 +3,52 @@ import copy from "copy-to-clipboard";
 
 import DisplayState from "./DisplayState";
 import CodePreview from "./CodePreview";
+import React, { ChangeEvent, useEffect } from "react"; // Import ChangeEvent, remove useState/useRef if not needed elsewhere
+import copy from "copy-to-clipboard";
+
+import DisplayState from "./DisplayState";
+import CodePreview from "./CodePreview";
 import Slider from "./Slider";
 import { useAtom } from "jotai";
-import { maxStepAtom, problemAtom, problemStateAtom, stepAtom } from "../atom";
-import { getProblem, getProblemSize } from "../api";
+// Import selectedTestCaseIndexAtom and remove problemAtom
+import { maxStepAtom, problemStateAtom, selectedTestCaseIndexAtom, stepAtom } from "../atom";
+// Remove getProblem, keep getProblemSize
+import { getProblemSize } from "../api";
+import { Problem } from "algo-lens-core"; // Import Problem type
 
-function ProblemVisualizer() {
+// Accept problem as a prop
+function ProblemVisualizer({ problem }: { problem: Problem<any, any> }) {
   const [state] = useAtom(problemStateAtom);
-  const [problem, setProblem] = useAtom(problemAtom);
-
   const [step, setStep] = useAtom(stepAtom);
   const [maxStep, setMaxStep] = useAtom(maxStepAtom);
+  // Add hooks for selected test case
+  const [selectedTestCaseIndex, setSelectedTestCaseIndex] = useAtom(selectedTestCaseIndexAtom);
 
-  if (!state || !problem) {
-    return null;
+   // Add useEffect for Max Step Update
+   useEffect(() => {
+    if (problem?.id && selectedTestCaseIndex >= 0) { // Check if problem.id exists and index is valid
+      console.log(`Visualizer: Fetching size for problem ${problem.id}, test case index ${selectedTestCaseIndex}`);
+      getProblemSize(problem.id, selectedTestCaseIndex)
+        .then((size) => {
+          console.log(`Visualizer: Received size ${size}`);
+          setMaxStep(size > 0 ? size : 1); // Ensure max is at least 1
+        })
+        .catch(error => { // Add error handling
+          console.error("Visualizer: Failed to fetch problem size:", error);
+          setMaxStep(1); // Fallback on error
+          // Optionally set a default max step or show an error
+        });
+    }
+   }, [problem?.id, selectedTestCaseIndex, setMaxStep]); // Add dependencies
+
+  if (!state || !problem) { // Check problem prop
+    return <p>Loading...</p>; // Or some other loading indicator
   }
-  const { title, code, id } = problem;
+  // Destructure testcases from problem prop
+  const { title, code, id, testcases } = problem;
 
   const breakpointToLineMap = new Map<number, number>();
-  const lines = code!.split("\n");
+  const lines = code ? code.split("\n") : []; // Handle potentially null code
   for (let i = 0; i < lines.length; i++) {
     const loc = lines[i];
     if (loc.trimStart().startsWith("//#")) {
@@ -36,20 +63,31 @@ function ProblemVisualizer() {
     }
   }
   const breakpoint = state.breakpoint;
-  const line = breakpointToLineMap.get(breakpoint);
+  // Handle potentially undefined breakpoint
+  const line = state.breakpoint ? breakpointToLineMap.get(state.breakpoint) : undefined;
 
   const handleSliderChange = (value: number) => {
     setStep(value);
   };
 
   const handleCopyCode = () => {
-    copy(code!);
-    alert("Code copied to clipboard!");
+    if(code) { // Check if code exists
+        copy(code);
+        alert("Code copied to clipboard!");
+    }
   };
 
-  useEffect(() => {
-    getProblemSize(problem.id!).then((size) => setMaxStep(size));
-  }, [problem]);
+  // Handler for test case change
+  const handleTestCaseChange = (e: ChangeEvent<HTMLSelectElement>) => {
+    const newIndex = parseInt(e.target.value, 10);
+    if (!isNaN(newIndex)) { // Ensure parsing was successful
+        console.log(`Visualizer: Setting test case index to ${newIndex}`);
+        setSelectedTestCaseIndex(newIndex);
+        setStep(1); // Reset step to 1 on test case change
+    }
+  };
+
+  // Remove the old useEffect that relied on problem from atom
 
   return (
     <div className="mx-8 my-8 flex-1">
@@ -82,6 +120,27 @@ function ProblemVisualizer() {
             <CodePreview code={code} highlightLineIndex={line} />
           </div>
           <div className="lg:pl-6 flex-1 lg:w-1/2  lg:p-2 space-y-4">
+             {/* Add Test Case Selector UI */}
+             <div className="flex items-center gap-2 mb-4"> {/* Added margin-bottom */}
+               <label htmlFor="testcase-select" className="font-medium">Select Test Case:</label>
+               <select
+                 id="testcase-select"
+                 className="select select-bordered select-sm" // Added DaisyUI classes
+                 value={selectedTestCaseIndex}
+                 onChange={handleTestCaseChange} // Use the handler function
+               >
+                 {/* Check if testcases exist before mapping */}
+                 {testcases?.map((tc, index) => (
+                   <option key={index} value={index}>
+                     {/* Use description if available, otherwise default text */}
+                     {tc.description ? `Case ${index + 1}: ${tc.description}` : `Test Case ${index + 1}`}
+                     {tc.isDefault ? ' (Default)' : ''} {/* Indicate default */}
+                   </option>
+                 ))}
+               </select>
+             </div>
+             {/* End Test Case Selector UI */}
+
             <div className="flex items-center gap-6">
               <Slider
                 min={1}

--- a/packages/frontend/src/pages/problem/ProblemView.tsx
+++ b/packages/frontend/src/pages/problem/ProblemView.tsx
@@ -1,36 +1,126 @@
 import { useAtom } from "jotai";
 import ProblemVisualizer from "../../components/ProblemVisualizer";
-import { maxStepAtom, problemAtom, problemStateAtom, stepAtom } from "../../atom";
-import { getProblem, getProblemState } from "../../api";
+import {
+  maxStepAtom,
+  problemAtom,
+  problemStateAtom,
+  selectedTestCaseIndexAtom, // Import the new atom
+  stepAtom,
+} from "../../atom";
+import { getProblem, getProblemSize, getProblemState } from "../../api"; // Import getProblemSize
 import { useEffect } from "react";
 
 export function useProblemState() {
-  const [problem, setProblem] = useAtom(problemAtom);
-  const [step, setStep] = useAtom(stepAtom);
-  const [state, setState] = useAtom(problemStateAtom);
+  const [problem] = useAtom(problemAtom); // Only need to read problem here
+  const [step] = useAtom(stepAtom); // Only need to read step
+  const [, setState] = useAtom(problemStateAtom); // Only need setter for state
+  const [selectedTestCaseIndex] = useAtom(selectedTestCaseIndexAtom); // Read the selected index
 
   useEffect(() => {
-    if (problem && step) {
+    // Ensure problem, step, and selectedTestCaseIndex are valid before fetching
+    if (problem?.id && step >= 1 && selectedTestCaseIndex >= 0) {
       const fetchState = async () => {
-        const s = await getProblemState(problem.id!, step);
-        setState(s);
+        try {
+          // Pass selectedTestCaseIndex to getProblemState
+          const s = await getProblemState(problem.id, selectedTestCaseIndex, step);
+          setState(s);
+        } catch (error) {
+          console.error(`Failed to fetch state for step ${step}, test case ${selectedTestCaseIndex}:`, error);
+          setState(null); // Reset state on error
+        }
       };
       fetchState();
+    } else {
+       // Reset state if dependencies are invalid (e.g., step becomes 0 or problem is null)
+       setState(null);
     }
-  }, [problem, step]);
+    // Add selectedTestCaseIndex to dependency array
+  }, [problem?.id, step, selectedTestCaseIndex, setState]); // Depend on problem.id for safety
 
-  return state;
+  // No need to return state, as it's managed globally
 }
+
 
 export default function ProblemView() {
   const [problem, setProblem] = useAtom(problemAtom);
-  const state = useProblemState();
+  const [state] = useAtom(problemStateAtom); // Read state for conditional rendering
+  const [, setMaxStep] = useAtom(maxStepAtom); // Need setter for maxStep
+  const [, setSelectedTestCaseIndex] = useAtom(selectedTestCaseIndexAtom); // Need setter for selected index
+  const [, setStep] = useAtom(stepAtom); // Need setter for step
 
-  async function init() {
-    console.log("init problem visualizer");
-    if (problem) {
-      return;
-    }
+
+  // Effect to initialize or react to problem changes (e.g., fetched or from static props)
+   useEffect(() => {
+    const initializeProblemData = async () => {
+      let currentProblem = problem; // Use the atom's current value
+
+      // If problem is not loaded yet, try fetching based on URL
+      if (!currentProblem) {
+        const url = new URL(window.location.href);
+        const id = url.searchParams.get("id");
+        if (id) {
+          console.log("Fetching problem with id", id);
+          try {
+            currentProblem = await getProblem(id);
+            if (currentProblem) {
+              setProblem(currentProblem); // Set the fetched problem globally
+            } else {
+               console.error("Problem not found for id:", id);
+               return; // Stop initialization if problem fetch fails
+            }
+          } catch (error) {
+            console.error("Failed to fetch problem:", error);
+            return; // Stop initialization on error
+          }
+        } else {
+           console.log("No ID in URL and no initial problem data.");
+           return; // Cannot initialize
+        }
+      }
+
+
+      // Proceed with initialization if we have a problem object
+      if (currentProblem) {
+        console.log("Initializing test case and size for problem:", currentProblem.id);
+        // Find default test case index
+        const defaultIndex = currentProblem.testcases?.findIndex(tc => tc.isDefault === true) ?? -1;
+        const initialIndex = defaultIndex >= 0 ? defaultIndex : 0;
+
+        // Check if test cases exist before setting index and fetching size
+        if (currentProblem.testcases && currentProblem.testcases.length > 0 && initialIndex < currentProblem.testcases.length) {
+           setSelectedTestCaseIndex(initialIndex);
+           setStep(1); // Reset step
+
+           try {
+             // Fetch initial size based on the determined initial index
+             const initialSize = await getProblemSize(currentProblem.id, initialIndex);
+             setMaxStep(initialSize > 0 ? initialSize : 1); // Ensure maxStep is at least 1
+             console.log(`Set initial test case index to ${initialIndex}, max steps to ${initialSize}`);
+           } catch (error) {
+              console.error(`Failed to get size for initial test case ${initialIndex}:`, error);
+              setMaxStep(1); // Fallback size
+           }
+        } else {
+            console.warn(`Problem ${currentProblem.id} has no test cases or invalid default index.`);
+            setSelectedTestCaseIndex(0); // Default to 0 even if no test cases exist
+            setStep(1);
+            setMaxStep(1); // No steps if no test cases
+        }
+      }
+    };
+
+    initializeProblemData();
+
+    // Re-run this effect if the problem ID changes (e.g., navigating between problem pages client-side if that were implemented)
+   }, [problem?.id, setProblem, setSelectedTestCaseIndex, setStep, setMaxStep]); // Use problem.id as primary dependency
+
+  // Use the globally managed problem state for rendering
+  const currentProblem = useAtom(problemAtom)[0]; // Read the latest problem value
+
+  // Render visualizer only when problem and state are ready
+  // Pass problem data as a prop to ProblemVisualizer
+  return <div>{currentProblem ? <ProblemVisualizer problem={currentProblem} /> : <p>Loading problem...</p>}</div>;
+}
     //get id from url query parameters
     const url = new URL(window.location.href);
     const id = url.searchParams.get("id");


### PR DESCRIPTION
Adds the ability for you to select different test cases for a problem directly from the frontend visualization view.

Key changes:
- Core: Added optional `isDefault` flag to `TestCase` interface.
- Backend:
    - Updated problem definitions (`testcase.ts`) to mark one case as default (initially for two-sum, 3sum, merge-intervals).
    - Modified state fetching API route to `/problem/:id/testcase/:testCaseIndex/state/:step`.
    - Updated size fetching API route (`/problem/:id/size`) to accept an optional `testCaseIndex` query parameter, defaulting to the default test case size.
    - Updated `ProblemStateCache` to handle caching per test case index.
    - Added API tests (`index.test.ts`) for the modified routes.
- Frontend:
    - Added `selectedTestCaseIndexAtom` for global state.
    - Updated `api.ts` to use the new API routes and parameters.
    - Modified `ProblemView.tsx` to initialize the selected test case based on the `isDefault` flag and fetch initial size correctly.
    - Modified `ProblemVisualizer.tsx` to add a dropdown selector, update the selected index state, reset the step count on change, and fetch the correct max steps for the selected test case.