### PR TITLE
feat: Display step description and adjust code preview size

### DIFF
--- a/packages/frontend/src/components/CodePreview.tsx
+++ b/packages/frontend/src/components/CodePreview.tsx
@@ -21,12 +21,12 @@ const CodePreview = ({ code, highlightLineIndex }) => {
       <pre
         ref={preRef}
         className="mockup-code rounded-lg text-xs font-code leading-none overflow-auto"
-        style={{ maxHeight: "80vh" }} // Adjust the maxHeight as needed
+        style={{ maxHeight: "70vh" }} // Adjust the maxHeight as needed
       >
         {code.split("\n").map((line, index) => (
           <p
             key={index}
-            className={`px-4 py-2 transition-all duration-100 ${
+            className={`px-4 py-1 transition-all duration-100 ${ // Reduced py padding from 2 to 1
               index === highlightLineIndex
                 ? "text-primary-content bg-primary highlighted"
                 : ""

--- a/packages/frontend/src/components/DisplayState.tsx
+++ b/packages/frontend/src/components/DisplayState.tsx
@@ -72,6 +72,12 @@ function DisplayState({
 
   return (
     <div className="lg:flex flex-col min-h-full items-center justify-start">
+      {/* Display the breakpoint description */}
+      {state.description && (
+        <div className="mb-4 p-4 border border-dashed border-gray-400 rounded-lg bg-gray-50 w-full text-center">
+          <p className="text-lg font-semibold text-gray-700">{state.description}</p>
+        </div>
+      )}
       <div className="grid grid-cols-2 gap-8 w-full">
         {variables.map((variable) => {
           const groupMeta = metadata!.groups?.find(


### PR DESCRIPTION
- Shows the step description (breakpoint description) at the top of the DisplayState component.
- Reduces the vertical size of the code preview in CodePreview.tsx to better fit the screen.