### PR TITLE
feat: Add SEO metadata using astro-seo

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -14,6 +14,7 @@
     "@tailwindcss/vite": "^4.1.4",
     "algo-lens-core": "*",
     "astro": "^5.6.1",
+    "astro-seo": "^0.8.4",
     "autoprefixer": "^10.4.19",
     "chart.js": "^4.4.2",
     "copy-to-clipboard": "^3.3.3",

--- a/packages/frontend/src/layouts/Layout.astro
+++ b/packages/frontend/src/layouts/Layout.astro
@@ -1,6 +1,13 @@
 ---
 import "../styles/global.css";
 import Navbar from "../components/Navbar.tsx";
+import { SEO } from "astro-seo";
+
+interface Props {
+  title?: string;
+}
+
+const { title = "Algo Lens" } = Astro.props;
 ---
 
 <!doctype html>
@@ -15,7 +22,17 @@ import Navbar from "../components/Navbar.tsx";
     <meta name="viewport" content="width=device-width" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="generator" content={Astro.generator} />
-    <title>Astro Basics</title>
+    <SEO
+      title={title}
+      description="Visualize algorithms and data structures with Algo Lens. An interactive tool for learning and understanding computer science concepts."
+      openGraph={{
+        basic: {
+          title: title,
+          description: "Visualize algorithms and data structures with Algo Lens. An interactive tool for learning and understanding computer science concepts.",
+          type: "website",
+        }
+      }}
+    />
   </head>
   <body>
     <Navbar client:load />

--- a/packages/frontend/src/pages/index.astro
+++ b/packages/frontend/src/pages/index.astro
@@ -7,7 +7,7 @@ import Layout from '../layouts/Layout.astro';
 // Don't want to use any of this? Delete everything in this file, the `assets`, `components`, and `layouts` directories, and start fresh.
 ---
 
-<Layout>
+<Layout title="Algo Lens - Home">
 	
 		<RandomProblemCard client:load/>
 	

--- a/packages/frontend/src/pages/problem/visualize.astro
+++ b/packages/frontend/src/pages/problem/visualize.astro
@@ -2,10 +2,27 @@
 import ProblemVisualizer from '../../components/ProblemVisualizer';
 import Layout from '../../layouts/Layout.astro';
 import ProblemView from './ProblemView';
+import { getProblem } from "../../api"; // Import the API function
 
+const { problemId } = Astro.params; // Get problemId from URL
+let pageTitle = "Algo Lens - Visualize Problem"; // Default title
 
+if (problemId) {
+  try {
+    const problem = await getProblem(problemId); // Fetch problem details
+    if (problem && problem.title) {
+      pageTitle = `Algo Lens - Visualize ${problem.title}`; // Construct dynamic title
+    }
+  } catch (error) {
+    console.error(`Failed to fetch problem details for ID ${problemId}:`, error);
+    // Keep the default title in case of error
+  }
+} else {
+  console.error("Problem ID not found in URL parameters.");
+  // Keep the default title if ID is missing
+}
 ---
 
-<Layout>
+<Layout title={pageTitle}> {/* Pass the dynamic title to Layout */}
 	<ProblemView client:load/>
 </Layout>


### PR DESCRIPTION
Integrates the `astro-seo` package to manage HTML metadata for improved SEO.

- Installs `astro-seo` dependency.
- Replaces the basic `<title>` tag in `Layout.astro` with the `SEO` component.
- Configures default title ("Algo Lens"), description, and basic Open Graph tags in the layout.
- Enables page-specific titles by passing a `title` prop to the `Layout` component.
- Sets a specific title ("Algo Lens - Home") for the index page.
- Dynamically generates titles for problem visualization pages (e.g., "Algo Lens - Visualize [Problem Name]") by fetching problem details.