### PR TITLE
Update problem contribution guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,4 +52,4 @@ https://github.com/user-attachments/assets/3e116275-0c40-4bb5-8a98-33ce40696248
 
 ## Adding New Problem Guidelines
 
-If you're interested in contributing new problems to AlgoLens, please refer to the [New Problem Guidelines](packages/backend/src/problem/NEW_PROBLEM_GUIDELINES.md) for instructions on file structure, comment guidelines, and more.
+If you're interested in contributing new problems to AlgoLens, please refer to the [Problem Contribution Guidelines](packages/backend/src/problem/guidelines/README.md) for detailed instructions on file structure, how to define steps, test cases, explanations, and more.

--- a/packages/backend/src/problem/guidelines/README.md
+++ b/packages/backend/src/problem/guidelines/README.md
@@ -25,10 +25,18 @@ This section provides links to detailed guidelines for the various files found w
 - [**Problem Guidelines**](./problem-guidelines.md): Guidelines for defining the problem's core structure and function signature in `problem.ts`, including type annotations and JSDoc.
 - [**Testcase Guidelines**](./testcase-guidelines.md): Guidelines for defining diverse and effective test cases in `testcase.ts`, critical for thorough problem validation.
 - [**Types Guidelines**](./types-guidelines.md): Guidelines for defining custom types and interfaces in `types.ts`, ensuring type safety and clarity.
-- [**Code Guidelines**](./code-guidelines.md): General guidelines for code implementation files within the `code/` directory, promoting consistent coding standards.
-- [**Podcast Script Guidelines**](./podcast-script-guidelines.md): Guidelines for writing engaging podcast scripts in `podcast_script.md` (if applicable).
+- [**Code Guidelines (`code/`)**](./code-guidelines.md): Guidelines for the optional `code/` directory, which can house supplementary code like solutions in other languages.
+- [**Podcast Script Guidelines (`podcast_script.md`)**](./podcast-script-guidelines.md): Guidelines for creating optional, engaging podcast-style scripts in `podcast_script.md`.
 
 ---
+
+## General Coding Style and Practices
+
+Across all files related to a problem contribution, please adhere to the following general practices:
+
+-   **Remove Unused Imports:** Ensure that your TypeScript/JavaScript files do not contain any unused imports. Linters and IDEs can usually help identify these.
+-   **Clean Code:** Write clean, readable, and well-commented code, especially within `steps.ts` to make the logic easy to follow.
+-   **Follow Specific Guidelines:** Prioritize adherence to the detailed guidelines provided for each specific file type.
 
 ---
 

--- a/packages/backend/src/problem/guidelines/code-guidelines.md
+++ b/packages/backend/src/problem/guidelines/code-guidelines.md
@@ -1,0 +1,36 @@
+# Code Guidelines (`code/`)
+
+This document provides guidelines for the content and structure of the `code/` directory within a specific problem folder (e.g., `packages/problem-free/problem-name/code/`).
+
+---
+
+## 1. Purpose
+
+The `code/` directory is intended as an **optional** space to store supplementary code related to the problem. This might include:
+
+-   Solutions in other programming languages (e.g., Python, Java, C++).
+-   Helper scripts or utility functions used for generating test cases or analyzing the problem, if not part of the main visualization logic.
+-   Alternative approaches or deprecated solutions that might still hold some informational value.
+
+**Currently, the usage of this directory is not strictly enforced, and for many problems, it may remain empty or contain only a `.gitkeep` file.**
+
+---
+
+## 2. Structure
+
+-   If providing solutions in other languages, use clear file names (e.g., `solution.py`, `Solution.java`).
+-   Organize files logically if multiple supplementary code snippets are included.
+
+---
+
+## 3. Best Practices
+
+-   **Clarity**: Ensure any code included is well-commented and easy to understand.
+-   **Relevance**: Only include code that is directly relevant to the problem.
+-   **Optionality**: Do not place core logic required for the AlgoLens visualization (which resides in `steps.ts`) in this directory. The visualization platform primarily uses `steps.ts`.
+
+---
+
+## 4. Current Status
+
+The active use of the `code/` directory for providing alternative solutions or extensive helper code is still evolving. As the platform grows, more specific guidelines may be developed if this directory becomes a more integral part of problem contributions. For now, its use is at the contributor's discretion for supplementary materials.

--- a/packages/backend/src/problem/guidelines/description-guidelines.md
+++ b/packages/backend/src/problem/guidelines/description-guidelines.md
@@ -12,47 +12,62 @@ To provide a clear, concise, and complete statement of the algorithmic problem, 
 
 ## 2. Structure
 
-A good problem description should include:
+A good problem description is crucial for user understanding and should clearly include the following sections:
 
-- **Problem Statement:**  
-  Clearly and succinctly state what the user is required to solve. Avoid ambiguity.
-
-- **Examples:**  
-  Provide at least one input/output example, with a brief explanation of how the output is derived.
-
-- **Constraints:**  
-  List any constraints (e.g., input size, value ranges, time/space limits) that affect the solution.
-
-- **Edge Cases:**  
-  Mention any special or tricky cases that users should consider.
-
-- **Language:**  
-  Use simple, direct language. Avoid jargon and overly complex sentences.
+-   **Problem Statement:**
+    -   Clearly and succinctly state what the user is required to solve. Avoid ambiguity.
+-   **Examples:**
+    -   Provide at least one, preferably two, clear input/output examples.
+    -   Include a brief explanation for each example showing how the output is derived from the input.
+    -   Format examples consistently for readability.
+-   **Constraints:**
+    -   List all relevant constraints (e.g., input size, value ranges for numbers, character sets for strings, time/space complexity hints if applicable).
+    -   This helps users understand the scale of the problem and potential edge cases.
+-   **Edge Cases (Optional but Recommended):**
+    -   Briefly mention any common or particularly tricky edge cases that users should consider (e.g., empty arrays, single-element inputs, inputs with all same values).
+-   **Language:**
+    -   Use simple, direct language. Avoid jargon and overly complex sentences.
 
 ---
 
-## 3. Example Template
+## 3. Markdown Template Example
 
-```
-## Problem
+Use the following markdown structure for clarity and consistency:
 
-Given an array of integers, return the maximum sum of any contiguous subarray.
+```markdown
+## Problem Statement
 
-## Example
+Given an array of integers `nums` and an integer `target`, return *indices of the two numbers such that they add up to `target`*.
 
-Input: nums = [-2,1,-3,4,-1,2,1,-5,4]  
-Output: 6  
-Explanation: The subarray [4,-1,2,1] has the largest sum = 6.
+You may assume that each input would have **exactly one solution**, and you may **not** use the same element twice.
+
+You can return the answer in any order.
+
+## Examples
+
+**Example 1:**
+
+-   **Input:** `nums = [2,7,11,15]`, `target = 9`
+-   **Output:** `[0,1]`
+-   **Explanation:** Because `nums[0] + nums[1] == 9`, we return `[0, 1]`.
+
+**Example 2:**
+
+-   **Input:** `nums = [3,2,4]`, `target = 6`
+-   **Output:** `[1,2]`
+-   **Explanation:** `nums[1] + nums[2] == 6`.
 
 ## Constraints
 
-- 1 <= nums.length <= 10^5
-- -10^4 <= nums[i] <= 10^4
+-   `2 <= nums.length <= 10^4`
+-   `-10^9 <= nums[i] <= 10^9`
+-   `-10^9 <= target <= 10^9`
+-   Only one valid answer exists.
 
-## Edge Cases
+## Edge Cases (Considerations)
 
-- All numbers are negative.
-- The array contains only one element.
+-   What if the array is at its minimum allowed length (e.g., 2 elements)?
+-   Input numbers can be negative.
 ```
 
 ---

--- a/packages/backend/src/problem/guidelines/explanation-guidelines.md
+++ b/packages/backend/src/problem/guidelines/explanation-guidelines.md
@@ -6,7 +6,7 @@ A strong explanation helps users understand the reasoning and approach behind a 
 
 ## 1. Purpose
 
-To explain the logic, approach, and reasoning behind the provided solution, making it accessible to users of varying backgrounds.
+To explain the logic, approach, and reasoning behind the provided solution, making it accessible to users of varying backgrounds. The `explanation.md` file is highly recommended for all problems. Even if a problem seems straightforward, a brief explanation of the chosen approach and complexity can be very beneficial for learners.
 
 ---
 

--- a/packages/backend/src/problem/guidelines/groups-guidelines.md
+++ b/packages/backend/src/problem/guidelines/groups-guidelines.md
@@ -58,6 +58,7 @@ export const groups: GroupMetadata[] = [
 - **Consistency:** Maintain consistent group names and labels across different problems where applicable.
 - **Concise Descriptions:** Keep descriptions brief but informative.
 - **Use Emojis:** Emojis can enhance visual appeal and quick recognition.
+- **Avoid Empty Groups:** Do not leave the `groups` array empty. Even for simple problems, consider default groups like "Input", "Computation", and "Output/Result" to maintain consistency.
 
 ---
 
@@ -67,6 +68,7 @@ export const groups: GroupMetadata[] = [
 - Using vague or unhelpful group names/labels.
 - Not assigning variables to appropriate groups in `variables.ts` (or `StepLoggerV2` calls).
 - Overlapping group definitions or redundant groups.
+- Exporting an empty array for `groups`. At a minimum, provide basic groups.
 
 ---
 

--- a/packages/backend/src/problem/guidelines/index-test-guidelines.md
+++ b/packages/backend/src/problem/guidelines/index-test-guidelines.md
@@ -29,7 +29,9 @@ import { problem } from "./problem"; // Import the problem definition
 import { runTests } from "algo-lens-core/src/test"; // Import the test runner utility
 
 it(problem.id, async () => {
-  await runTests(problem);
+  // Pass the directory path to runTests
+  // The runTests utility will dynamically load problem details from this directory
+  await runTests(__dirname);
 });
 ```
 
@@ -37,8 +39,8 @@ it(problem.id, async () => {
 
 ## 4. Explanation
 
-- **`problem.id`:** Used as the name for the test block, ensuring unique and identifiable test runs.
-- **`runTests(problem)`:** This function takes the `problem` object (which contains references to `testcases.ts` and the solution function) and executes all defined test cases against the problem's solution. It handles assertions and reports results.
+- **`problem.id`:** Imported from `./problem` and used as the name for the test block, ensuring unique and identifiable test runs.
+- **`runTests(__dirname)`:** This function takes the current directory path (`__dirname`). The testing utility uses this path to dynamically locate and load the `problem.ts`, `testcase.ts`, and other necessary files for the specific problem being tested. It then executes all defined test cases against the problem's solution logic and handles assertions and results reporting.
 
 ---
 

--- a/packages/backend/src/problem/guidelines/podcast-script-guidelines.md
+++ b/packages/backend/src/problem/guidelines/podcast-script-guidelines.md
@@ -1,0 +1,81 @@
+# Podcast Script Guidelines (`podcast_script.md`)
+
+This document outlines guidelines for creating `podcast_script.md` files, which can provide an engaging audio-style explanation for a problem. This is an **optional** file for each problem.
+
+---
+
+## 1. Purpose
+
+The `podcast_script.md` file aims to offer an alternative way for users to understand the problem and its solution through a conversational script format, similar to a podcast episode. It can make complex topics more approachable and engaging.
+
+---
+
+## 2. Structure
+
+A typical podcast script for a problem should include the following sections:
+
+-   **Title/Episode Name:** A catchy title for the "episode."
+-   **Hosts (Optional):** You can define 1-2 host names to make the conversation flow naturally.
+-   **Introduction:**
+    -   Welcome message.
+    -   Briefly introduce the problem to be discussed.
+-   **Problem Statement:**
+    -   Clearly state the problem, what's given, and what needs to be achieved.
+-   **Initial Thoughts / Brute-Force Approach:**
+    -   Discuss the most straightforward or naive way to solve the problem.
+    -   Analyze its drawbacks (usually time complexity).
+-   **Optimized Approach / Key Insights:**
+    -   Introduce the core idea or technique for a more efficient solution (e.g., sorting, two-pointers, dynamic programming).
+    -   Explain how this technique applies to the current problem.
+-   **Step-by-Step Breakdown of the Optimized Solution:**
+    -   Walk through the algorithm logically.
+    -   Explain how data structures are used.
+    -   Discuss handling of edge cases or specific conditions (like duplicates in 3Sum).
+-   **Complexity Analysis:**
+    -   Discuss the time and space complexity of the optimized solution.
+-   **Conclusion/Summary:**
+    -   Recap the main points of the solution.
+    -   Offer encouragement or final thoughts.
+-   **Outro:**
+    -   Sign-off.
+
+---
+
+## 3. Example Snippet (from 3Sum)
+
+```markdown
+# Podcast: Algocast - Visualize algorithms
+
+**Episode:** Solving the 3Sum Problem Efficiently
+
+**Hosts:** Alex & Ben
+
+**Alex:** Hey everyone, and welcome back to "Algolens"! I'm Alex.
+
+**Ben:** And I'm Ben. Today, we're tackling a classic problem often seen in interviews: the 3Sum problem.
+
+**Alex:** Right. The task sounds simple enough: given a list of numbers, find all the unique combinations of three distinct numbers from that list that add up to exactly zero.
+...
+```
+
+---
+
+## 4. Tone and Style
+
+-   **Conversational:** Write as if two people are naturally discussing the problem.
+-   **Clear and Concise:** Avoid overly technical jargon where possible, or explain it clearly.
+-   **Engaging:** Make it interesting for someone learning the algorithm.
+-   **Target Audience:** Assume the listener has some basic programming knowledge but might be new to the specific algorithm or problem.
+
+---
+
+## 5. Best Practices
+
+-   **Logical Flow:** Ensure the discussion progresses smoothly from understanding the problem to the optimized solution.
+-   **Role of Hosts:** If using multiple "hosts," assign them distinct roles or perspectives if it helps the flow (e.g., one asks clarifying questions, the other explains).
+-   **Review:** Read the script aloud to check for natural language and flow.
+-   **Optionality:** Remember, this file is optional. Only create it if you feel it adds significant value to the problem's explanation.
+
+---
+
+By following these guidelines, you can create informative and engaging podcast scripts that enhance the learning experience on AlgoLens.

--- a/packages/backend/src/problem/guidelines/problem-guidelines.md
+++ b/packages/backend/src/problem/guidelines/problem-guidelines.md
@@ -32,28 +32,56 @@ A good `problem.ts` file should define a `Problem` object, typically including:
 ## 3. Example Template
 
 ```ts
-import { Problem } from '../../types/problem';
+import { Problem, ProblemState } from "algo-lens-core/src/types"; // Adjusted import
+import fs from "fs"; // For reading markdown files
+import path from "path"; // For constructing file paths
 import { generateSteps } from './steps';
 import { testcases } from './testcase';
 import { variables } from './variables';
 import { groups } from './groups';
-import { explanation } from './explanation.md';
-import { ExampleType } from './types'; // Example of importing a type
+// Assuming types.ts defines YourProblemInputType and YourProblemReturnType
+import { YourProblemInputType } from './types';
 
-export const problem: Problem<ExampleType> = {
-  id: 'example-problem',
-  title: 'Example Problem Title',
-  emoji: '💡',
-  difficulty: 'medium',
-  tags: ['Array', 'Logic'],
-  generateSteps,
-  testcases,
-  explanation,
-  variables,
-  groups,
+// Read description and explanation from markdown files
+// This is the current common practice.
+let description = "";
+try {
+  description = fs.readFileSync(path.join(__dirname, 'description.md'), 'utf-8');
+} catch (e) { console.error("Error reading description.md for problem"); }
+
+let explanation = ""; // Optional, but highly recommended
+try {
+  explanation = fs.readFileSync(path.join(__dirname, 'explanation.md'), 'utf-8');
+} catch (e) { /* Explanation file might be missing, handle gracefully */ }
+
+export const problem: Problem<YourProblemInputType, ProblemState> = {
+  // Core Metadata
+  id: 'your-problem-id', // Use kebab-case (e.g., "two-sum", "longest-substring")
+  title: 'Your Problem Title',
+  emoji: '💡', // Choose a relevant emoji
+  difficulty: 'medium', // 'easy', 'medium', or 'hard'
+  tags: ['Array', 'Logic', 'YourProblemTag'], // Relevant algorithm tags
+
+  // Content
+  description, // Loaded from description.md
+  explanation, // Loaded from explanation.md (if exists)
+
+  // Core Logic & Test Cases
+  func: generateSteps, // Function from steps.ts that generates visualization steps
+  testcases,         // Imported from testcase.ts
+
+  // Visualization Metadata
+  metadata: {
+    variables, // Imported from variables.ts
+    groups,    // Imported from groups.ts
+  },
+
+  // Code Generation Signature (for potential future use or external tools)
   codeGenerationSignature: {
-    signature: 'function exampleFunction(input: ExampleType): number[]',
-    name: 'exampleFunction',
+    // Name of the function users would typically implement
+    name: 'yourProblemFunction',
+    // Full TypeScript signature of that function
+    signature: 'function yourProblemFunction(input: YourProblemInputType): YourProblemReturnType',
   },
 };
 ```
@@ -62,17 +90,30 @@ export const problem: Problem<ExampleType> = {
 
 ## 4. Best Practices
 
--   **Modularity:** Keep the `problem.ts` file focused on defining the problem's metadata and linking to other files. The actual step-by-step logic, types, test cases, and variables should reside in their respective dedicated files (`steps.ts`, `types.ts`, `testcase.ts`, `variables.ts`, `groups.ts`).
+-   **`id` Casing**: Use `kebab-case` for problem `id` strings (e.g., "two-sum", "merge-intervals") for consistency with the plop generator and general URL/file naming conventions.
+-   **Markdown Content**:
+    -   Load `description.md` and `explanation.md` content using `fs.readFileSync` as shown in the template. Ensure these files exist or handle potential errors gracefully.
+    -   The `description` property in the `Problem` object is essential.
+    -   The `explanation` property is highly recommended.
+-   **`metadata` Object**: Place `variables` and `groups` inside the `metadata` object as per common practice.
+-   **`codeGenerationSignature`**:
+    -   Use the property name `codeGenerationSignature`.
+    -   Ensure it includes both `name` (the typical function name a user would write, e.g., `twoSum`) and `signature` (the full TypeScript signature of such a function).
+-   **Modularity:** Keep the `problem.ts` file focused on defining the problem's metadata and linking to other files. The actual step-by-step logic (`steps.ts`), types (`types.ts`), test cases (`testcase.ts`), variables (`variables.ts`), and groups (`groups.ts`) should reside in their respective dedicated files.
 -   **Consistency:** Follow established coding conventions and style guides.
--   **Clear Referencing:** Ensure all imported components (steps, testcases, variables, types, explanation) are correctly referenced and aligned with the problem's definition.
+-   **Clear Referencing:** Ensure all imported components are correctly referenced.
 
 ---
 
 ## 5. Common Mistakes
 
--   Placing the entire solution logic or function implementation directly in `problem.ts` instead of delegating to `steps.ts` for visualization.
--   Defining problem-specific types, test cases, or variables directly in `problem.ts` instead of importing them from `types.ts`, `testcase.ts`, or `variables.ts` respectively.
--   Missing or incorrect references to required external files (e.g., `steps.ts`, `testcase.ts`).
+-   Inconsistent `id` casing.
+-   Not including `description` content in the problem object.
+-   Placing `variables` or `groups` at the top level instead of within `metadata`.
+-   Using `codegen` instead of `codeGenerationSignature`, or omitting the `name` field within it.
+-   Typos in the function name within `codeGenerationSignature.name` (e.g., `threeSteps` instead of `threeSum`).
+-   Placing the entire solution logic or function implementation directly in `problem.ts`.
+-   Defining problem-specific types, test cases, or variables directly in `problem.ts`.
 
 ---
 

--- a/packages/backend/src/problem/guidelines/steps-guidelines.md
+++ b/packages/backend/src/problem/guidelines/steps-guidelines.md
@@ -51,9 +51,10 @@ Following these ensures clear, informative visualizations.
      - `l.simple(value)`
      - `l.setMeta(name, metadata)`
      - `l.tree(label, value, highlight?)`
+     - `l.grid(name, values, ...pointers)`: Note that `l.array2d` was used in some older problems but `l.grid` is the preferred method for 2D array/grid visualizations. If you encounter `l.array2d`, consider updating to `l.grid` if appropriate.
 
 4. **Pointer Labels and Colors:**
-   - For `l.arrayV3`/`l.hashmapV2` pointers:
+   - For `l.arrayV3`/`l.hashmapV2`/`l.grid` pointers:
      - Use short, lowercase `label`.
      - Use DaisyUI color names (e.g., "primary", "success") for `color`.
 
@@ -148,6 +149,7 @@ export function generateSteps(n: number): ProblemState[] {
 - Keep comments short and focused on the current step.
 - Use pointer labels and colors to clarify what each pointer represents.
 - Use metadata and group/hashmap options for advanced display needs.
+- Optionally, for self-documentation within `steps.ts`, you can add comments indicating which logical group a variable might belong to (e.g., `// 'n' belongs to 'input' group`), although the primary definition of groups is in `groups.ts`.
 
 ### Common Pitfalls
 

--- a/packages/backend/src/problem/guidelines/testcase-guidelines.md
+++ b/packages/backend/src/problem/guidelines/testcase-guidelines.md
@@ -12,54 +12,55 @@ To define the specific input and expected output for each test case, allowing fo
 
 ## 2. Structure
 
-Each test case should be an object with the following properties:
+Each test case **must** be an object adhering to the `TestCase` type imported from `algo-lens-core/src/types`. It should have the following properties:
 
-- **`name` (string):** A unique name for the test case.
-- **`description` (string):** A clear and concise description of what this test case is testing (e.g., "basic positive numbers", "empty array", "large input").
-- **`input` (object):** An object containing the input variables for the problem's function. The keys should match the parameter names of the problem's function.
-- **`expected` (any):** The expected output from the problem's function for the given input.
+-   **`name` (string):** A unique, descriptive name for the test case (e.g., "Basic positive numbers", "Empty array input").
+-   **`description` (string):** A clear and concise explanation of what this specific test case is testing.
+-   **`input` (object):**
+    -   This **must** be an object where keys are the parameter names of the problem's main function (as defined in `steps.ts` and `types.ts`).
+    -   For example, if the function is `twoSum(nums: number[], target: number)`, the input object should be `{ nums: [...], target: ... }`.
+    -   Even for functions with a single parameter (e.g., `climbStairs(n: number)`), use an object: `{ n: 5 }`. This consistency is important.
+-   **`expected` (any):** The expected output from the problem's function for the given input. The type of this will depend on the problem's return type.
+-   **`isDefault` (boolean, optional):** If `true`, this test case might be preferentially shown or used by default in the UI. Only one test case should be marked as default.
 
 ---
 
 ## 3. Example Template
 
 ```ts
-import { ProblemState, TestCase } from "algo-lens-core/src/types";
+import { TestCase } from "algo-lens-core/src/types";
+// Assuming YourProblemInputType is defined in ./types.ts
+// e.g., interface YourProblemInputType { nums: number[]; target: number; }
+// Assuming YourProblemReturnType is the expected output type, e.g., number[] or ProblemState
+import { YourProblemInputType, YourProblemReturnType } from "./types";
 
-import { ThreeSumInput } from "./types";
-
-export const testcases: TestCase<ThreeSumInput, ProblemState>[] = [
+export const testcases: TestCase<YourProblemInputType, YourProblemReturnType>[] = [
   {
-    name: "Basic Positive",
-    description: "This test case covers a fundamental scenario with an array of positive integers and a target sum that can be achieved by summing two elements within the array. It validates the basic functionality of finding the correct indices.",
-    input: { nums: [2, 7, 11, 15], target: 9 },
+    name: "Example 1: Basic Case",
+    description: "A fundamental scenario testing the primary logic.",
+    input: { nums: [2, 7, 11, 15], target: 9 }, // Input is an object
     expected: [0, 1],
     isDefault: true,
   },
   {
-    name: "Negative Numbers",
-    description: "This test case evaluates the solution's ability to handle arrays containing negative numbers. The target sum is also negative, requiring the algorithm to correctly identify two negative numbers that sum up to the target.",
-    input: { nums: [-1, -2, -3, -4], target: -3 },
-    expected: [0, 1],
+    name: "Example 2: No Solution",
+    description: "Tests behavior when no solution exists.",
+    input: { nums: [1, 2, 3], target: 7 },
+    expected: [], // Or appropriate "no solution" output
   },
   {
-    name: "Empty Array",
-    description: "This test case specifically checks the behavior of the solution when provided with an empty input array. It ensures that the algorithm gracefully handles this edge case and returns an empty result as expected.",
-    input: { nums: [], target: 0 },
+    name: "Edge Case: Empty Array",
+    description: "Tests handling of an empty input array.",
+    input: { nums: [], target: 5 },
     expected: [],
   },
+  // Example for a single argument function like climbStairs(n: number)
   {
-    name: "Single Element",
-    description: "This test case examines the solution's response to an array containing only a single element. It's crucial for verifying edge case handling where a pair cannot be formed.",
-    input: { nums: [5], target: 5 },
-    expected: [], // Or appropriate expected output for single element
-  },
-  {
-    name: "Large Input",
-    description: "This test case is designed to assess the performance and efficiency of the solution when dealing with a very large input array. It helps identify potential bottlenecks or scalability issues.",
-    input: { nums: Array.from({ length: 10000 }, (_, i) => i), target: 19999 },
-    expected: [9999, 10000],
-  },
+    name: "Climbing Stairs: n = 3",
+    description: "Test case for 3 stairs.",
+    input: { n: 3 }, // Input is still an object
+    expected: 3,
+  }
 ];
 ```
 
@@ -67,21 +68,22 @@ export const testcases: TestCase<ThreeSumInput, ProblemState>[] = [
 
 ## 4. Best Practices
 
-- **Variety:**  
-  Include a diverse set of test cases covering:
-    - Basic/typical scenarios.
-    - Edge cases (e.g., empty inputs, single elements, boundary values, nulls/undefineds if applicable).
-    - Large inputs to test performance.
-    - Invalid inputs (if the problem specifies how to handle them).
-
-- **Clarity:**  
-  Ensure the `description` clearly explains the purpose of each test case.
-
-- **Accuracy:**  
-  The `expected` output must be precisely correct for the given `input`.
-
-- **Consistency:**  
-  Maintain consistent naming and typing for `input` variables as defined in `problem.ts`.
+-   **Object Inputs:** Always structure the `input` field as an object, with keys matching the parameter names of your function in `steps.ts`.
+-   **Type Safety:**
+    -   Always import the `TestCase` type from `algo-lens-core/src/types`.
+    -   Explicitly type your `testcases` array: `const testcases: TestCase<MyInputType, MyOutputType>[] = [...]`.
+    -   Ensure `MyInputType` (imported from `./types.ts`) correctly defines the structure of your input object.
+-   **Variety:**
+    Include a diverse set of test cases covering:
+    -   Basic/typical scenarios.
+    -   Edge cases (e.g., empty inputs, single elements, boundary values).
+    -   Cases that test different logical paths in your solution.
+    -   Large inputs if performance is a consideration (though step generation limits might apply).
+-   **Clarity:**
+    Ensure the `name` and `description` clearly explain the purpose and scenario of each test case.
+-   **Accuracy:**
+    The `expected` output must be precisely correct for the given `input`.
+-   **`isDefault`:** Use `isDefault: true` sparingly for one representative test case.
 
 ---
 

--- a/packages/backend/src/problem/guidelines/types-guidelines.md
+++ b/packages/backend/src/problem/guidelines/types-guidelines.md
@@ -48,35 +48,48 @@ export interface TreeNode {
 /**
  * Represents an interval with a start and end value.
  */
-export type Interval = [number, number];
+export type Interval = [number, number]; // Example of a simple type alias
 
 /**
- * Custom input type for a problem.
+ * Input type for a problem like Two Sum.
+ * Following the best practice of using an object for test case inputs.
  */
-export interface MyProblemInput {
-  data: number[];
-  config: {
-    mode: "strict" | "loose";
-    maxItems: number;
-  };
+export interface TwoSumInput {
+  nums: number[];
+  target: number;
 }
+
+/**
+ * Input type for a problem like Climbing Stairs.
+ * Even for a single parameter, an object is preferred for consistency.
+ */
+export interface ClimbingStairsInput {
+  n: number;
+}
+
+/**
+ * Example of an expected return type, if it's complex.
+ * For simple returns like number or number[], this might not be needed.
+ */
+export type MyProblemReturnType = number[]; // Or more complex object/ProblemState
 ```
 
 ---
 
 ## 4. Best Practices
 
-- **Specificity:**  
-  Define types as specifically as possible to leverage TypeScript's type-checking capabilities.
-
-- **Reusability:**
-  If a type is used across multiple problems, consider defining it in a shared location (e.g., `algo-lens-core/src/types.ts`). This is the designated location for common problem-related types.
-
-- **Consistency:**  
-  Ensure type definitions are consistent with their usage in `problem.ts`, `steps.ts`, and `testcase.ts`.
-
-- **Readability:**  
-  Organize types logically and use proper indentation.
+-   **Input Object Types:**
+    -   Always define an interface or type alias for the `input` object structure used in `testcase.ts`.
+    -   The keys in this type should match the parameter names of your main function in `steps.ts`.
+    -   Example: If `testcase.ts` has `input: { data: number[], limit: number }`, then `types.ts` should have `export interface MyProblemInput { data: number[]; limit: number; }`.
+-   **Specificity:**
+    Define types as specifically as possible to leverage TypeScript's type-checking capabilities.
+-   **Reusability:**
+    If a type is general enough to be used across multiple problems (e.g., `ListNode`, `TreeNode`), it should ideally be defined in the shared `algo-lens-core/src/types.ts` file. Problem-specific types remain in the problem's `types.ts`.
+-   **Consistency:**
+    Ensure type definitions are consistent with their usage in `problem.ts`, `steps.ts`, and `testcase.ts`.
+-   **Readability:**
+    Organize types logically and use proper indentation and JSDoc comments where necessary.
 
 ---
 

--- a/packages/backend/src/problem/guidelines/variables-guidelines.md
+++ b/packages/backend/src/problem/guidelines/variables-guidelines.md
@@ -14,8 +14,8 @@ To define metadata (display name, description, emoji) for each significant varia
 
 The `variables.ts` file should export an array of `VariableMetadata` objects. Each `VariableMetadata` object describes a single variable:
 
-- **`name` (string):** The exact name of the variable as it appears in the code (e.g., `n`, `dp`, `i`, `result`). This is used for internal mapping.
-- **`label` (string):** The display name for the variable, shown in the user interface (e.g., "Target Step", "DP Array", "Loop Counter").
+- **`name` (string):** The exact name of the variable as it appears in the code (e.g., `n`, `dp`, `i`, `result`). This is used for internal mapping and **must** match the code.
+- **`label` (string):** The human-readable display name for the variable, shown in the user interface (e.g., "Target Step", "DP Array", "Current Index"). This field is **highly recommended** for all variables to ensure clarity in the UI, even if it's similar to the `name`.
 - **`description` (string):** A clear and concise explanation of the variable's purpose, what it represents, and how it's used in the algorithm.
 - **`emoji` (string, optional):** An emoji to visually represent the variable in the UI (e.g., "🎯", "🔢", "🔄", "🏁").
 
@@ -59,11 +59,11 @@ export const variables: VariableMetadata[] = [
 
 ## 4. Best Practices
 
-- **Exact `name` Match:** Ensure the `name` property exactly matches the variable name used in `steps.ts` and `problem.ts`.
-- **Clear `label`:** The `label` should be user-friendly and descriptive, even if the `name` is a common abbreviation.
+- **Exact `name` Match:** Ensure the `name` property exactly matches the variable name used in `steps.ts` when logging (e.g., `l.simple({ myVar: ... })` means `name: "myVar"`).
+- **Provide `label`:** Always provide a `label`. While it can be similar to `name` for self-descriptive variable names, it's good practice to define it explicitly for UI consistency.
 - **Comprehensive `description`:** Explain the variable's role, its contents (especially for data structures), and how it contributes to the algorithm.
 - **Relevant `emoji`:** Choose emojis that intuitively represent the variable's meaning or type.
-- **All Key Variables:** Include metadata for all variables that are logged or are crucial for understanding the algorithm's state.
+- **All Logged Variables:** Include metadata for all variables that are logged with `StepLoggerV2` and are intended to be visible and understandable to the user.
 
 ---
 


### PR DESCRIPTION
Analyzed existing problems (two-sum, 3sum, climbingStairs) to identify discrepancies between current practices and documented guidelines.

Updated and created guideline markdown files in `packages/backend/src/problem/guidelines/` to:
- Reflect common, established practices (e.g., `runTests(__dirname)` in `index.test.ts`, `metadata` object in `problem.ts`).
- Clarify ambiguous rules (e.g., loading markdown, `variables.ts` labels).
- Enforce best practices (e.g., object structure for `testcase.ts` inputs).
- Add missing guidelines (`code-guidelines.md`, `podcast-script-guidelines.md`).
- Corrected the main README.md to point to the new guideline directory.
- Added general coding style notes to the guidelines README.md.

These changes aim to make the guidelines more accurate, comprehensive, and easier for contributors to follow.