### PR TITLE
feat: Add script to generate mock podcast audio files

### DIFF
--- a/packages/problem-free/package.json
+++ b/packages/problem-free/package.json
@@ -4,7 +4,8 @@
     "dev": "PORT=4005 bun run --hot src/index.ts",
     "test:watch": "bun test --watch",
     "test": "bun test",
-    "build:check": "tsc --noEmit"
+    "build:check": "tsc --noEmit",
+    "generate-audio": "bun run scripts/generate-audio.ts"
   },
   "dependencies": {
     "dotenv": "^16.5.0",

--- a/packages/problem-free/scripts/README.md
+++ b/packages/problem-free/scripts/README.md
@@ -1,0 +1,24 @@
+# Podcast Audio Generation Script
+
+This script is used to generate (mock) audio files for podcast scripts associated with each programming problem.
+
+## Usage
+
+To run the script, navigate to the `packages/problem-free` directory and execute the following command:
+
+```bash
+bun run generate-audio
+```
+
+This will iterate through all problem directories within `packages/problem-free` (excluding `scripts` and `node_modules`). For each problem, it will:
+
+1. Look for a `podcast_script.md` file.
+2. If found, it will call a (currently mocked) audio generation function.
+3. This mock function will create an empty audio file named `<problem-name>_audio.mp3` in the problem's directory.
+4. It will log the progress and any errors encountered.
+
+If a `podcast_script.md` file is not found for a particular problem, a warning will be logged, and that problem will be skipped.
+
+## Output
+
+The script will create empty `.mp3` files in each problem's directory (e.g., `packages/problem-free/3sum/3sum_audio.mp3`). Logs will be printed to the console indicating the success or failure of audio generation for each problem.

--- a/packages/problem-free/scripts/generate-audio.ts
+++ b/packages/problem-free/scripts/generate-audio.ts
@@ -1,0 +1,43 @@
+import fs from 'fs/promises';
+import path from 'path';
+
+const problemsDir = path.join(__dirname, '..');
+
+async function generateAudioFromScript(scriptContent: string, outputPath: string): Promise<void> {
+  console.log(`Mocking audio generation for: ${outputPath}`);
+  // In a real scenario, this function would call an API to generate audio.
+  // For now, we'll just create an empty file.
+  await fs.writeFile(outputPath, '');
+  console.log(`Successfully created empty audio file at: ${outputPath}`);
+}
+
+async function main() {
+  try {
+    const problemNames = (await fs.readdir(problemsDir, { withFileTypes: true }))
+      .filter(dirent => dirent.isDirectory() && dirent.name !== 'scripts' && dirent.name !== 'node_modules')
+      .map(dirent => dirent.name);
+
+    for (const problemName of problemNames) {
+      const problemPath = path.join(problemsDir, problemName);
+      const podcastScriptPath = path.join(problemPath, 'podcast_script.md');
+      const audioOutputPath = path.join(problemPath, `${problemName}_audio.mp3`);
+
+      try {
+        const scriptContent = await fs.readFile(podcastScriptPath, 'utf-8');
+        await generateAudioFromScript(scriptContent, audioOutputPath);
+      } catch (error: any) {
+        if (error.code === 'ENOENT') {
+          console.warn(`Skipping ${problemName}: podcast_script.md not found at ${podcastScriptPath}`);
+        } else {
+          console.error(`Error processing problem ${problemName}:`, error);
+        }
+      }
+    }
+    console.log('\nMock audio generation complete for all problems.');
+  } catch (error) {
+    console.error('Failed to generate podcast audio:', error);
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
Adds a new script `packages/problem-free/scripts/generate-audio.ts` that can be run via `bun run generate-audio` from the `packages/problem-free` directory.

The script iterates through each problem, reads its `podcast_script.md`, and creates a mock (empty) audio file named `<problem-name>_audio.mp3` in the problem's directory.

Includes a README for the script and updates `package.json` with the new run command.