### PR TITLE
Fix: Ensure problem description and explanation are correctly typed a…

### DIFF
--- a/packages/algo-lens-core/src/types.ts
+++ b/packages/algo-lens-core/src/types.ts
@@ -35,6 +35,9 @@ export interface Problem<Input, State> {
 
   difficulty: Difficulty;
 
+  description?: string; // Content from description.md
+  explanation?: string; // Content from explanation.md
+
   metadata: ProblemMetadata;
 
   codegen?: {

--- a/packages/frontend/src/components/ProblemVisualizer.tsx
+++ b/packages/frontend/src/components/ProblemVisualizer.tsx
@@ -194,8 +194,8 @@ function ProblemVisualizer({ state }: ProblemVisualizerProps) {
             <div className="description-content">
               {/* Display problem description or fallback */}
               <div className="p-4">
-                {(problem as any)?.description ? (
-                  <p>{(problem as any).description}</p> // Assuming description is plain text
+                {problem?.description ? (
+                  <p>{problem.description}</p> // Assuming description is plain text
                 ) : (
                   <p>No description available.</p>
                 )}
@@ -208,8 +208,8 @@ function ProblemVisualizer({ state }: ProblemVisualizerProps) {
             <div className="explanation-content p-4">
               {" "}
               {/* Added padding */}
-              {(problem as any)?.explanation ? (
-                <p>{(problem as any).explanation}</p>
+              {problem?.explanation ? (
+                <p>{problem.explanation}</p>
               ) : (
                 "No explanation available. (Work in progress)"
               )}


### PR DESCRIPTION
…nd accessed

- Updated the `Problem` type in `algo-lens-core` to include optional `description` and `explanation` fields.
- Modified `ProblemVisualizer.tsx` to access `problem?.description` and `problem?.explanation` directly, removing the previous `as any` cast.

This should resolve issues where the problem description or explanation were not displayed correctly due to type mismatches, assuming the backend provides these fields.