### PR TITLE
feat: Add podcast player to problem view

### DIFF
--- a/packages/algo-lens-core/src/types.ts
+++ b/packages/algo-lens-core/src/types.ts
@@ -47,6 +47,7 @@ export interface Problem<Input, State> {
     signature: string;
   };
   bookmark?: boolean;
+  podcastUrl?: string;
 }
 
 export type ProblemGroup = {

--- a/packages/frontend/src/components/icons/PlayIcon.tsx
+++ b/packages/frontend/src/components/icons/PlayIcon.tsx
@@ -1,0 +1,21 @@
+// PlayIcon.tsx
+import type { SVGProps } from "react";
+
+export default function PlayIcon(props: SVGProps<SVGSVGElement>) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      {...props}
+    >
+      <polygon points="5 3 19 12 5 21 5 3" />
+    </svg>
+  );
+}

--- a/packages/frontend/src/pages/problem/ProblemView.tsx
+++ b/packages/frontend/src/pages/problem/ProblemView.tsx
@@ -12,6 +12,7 @@ import { useEffect, useState } from "react"; // Import useState
 import { pb } from "../../auth/pocketbase"; // Import pb
 import BookmarkButton from "../../bookmark/BookmarkButton";
 import { trackUmamiEvent } from "../../utils/umami";
+import PlayIcon from "../../components/icons/PlayIcon"; // Import a play icon
 
 export function useProblemState() {
   const [problem] = useAtom(problemAtom);
@@ -41,6 +42,52 @@ export default function ProblemView() {
   const [problem, setProblem] = useAtom(problemAtom);
   const [step] = useAtom(stepAtom);
   const state = useProblemState();
+  const [audio, setAudio] = useState<HTMLAudioElement | null>(null);
+  const [isPlaying, setIsPlaying] = useState(false);
+
+  // Function to toggle play/pause
+  const togglePlayPause = () => {
+    if (audio) {
+      if (isPlaying) {
+        audio.pause();
+      } else {
+        audio.play();
+      }
+      setIsPlaying(!isPlaying);
+    }
+  };
+
+  useEffect(() => {
+    if (problem?.podcastUrl) {
+      const audioElement = new Audio(problem.podcastUrl);
+      setAudio(audioElement);
+
+      // Event listeners for the audio element
+      const handlePlay = () => setIsPlaying(true);
+      const handlePause = () => setIsPlaying(false);
+      const handleEnded = () => setIsPlaying(false);
+
+      audioElement.addEventListener("play", handlePlay);
+      audioElement.addEventListener("pause", handlePause);
+      audioElement.addEventListener("ended", handleEnded);
+
+      // Cleanup
+      return () => {
+        audioElement.removeEventListener("play", handlePlay);
+        audioElement.removeEventListener("pause", handlePause);
+        audioElement.removeEventListener("ended", handleEnded);
+        audioElement.pause(); // Ensure audio stops if component unmounts
+        setAudio(null); // Clear the audio object
+      };
+    } else {
+      // Ensure audio is stopped and cleared if podcastUrl is not present or removed
+      if (audio) {
+        audio.pause();
+        setAudio(null);
+      }
+      setIsPlaying(false);
+    }
+  }, [problem?.podcastUrl]);
 
   async function init() {
     //
@@ -74,5 +121,36 @@ export default function ProblemView() {
   //console.log("ProblemView - problem:", problem);
   //console.log("ProblemView - state:", state);
   // Temporarily remove conditional rendering and pass problem and state directly for debugging
-  return <div>{state && <ProblemVisualizer state={state} />}</div>;
+  return (
+    <div>
+      {problem?.podcastUrl && (
+        <div className="mb-4 flex items-center justify-end">
+          <button
+            onClick={togglePlayPause}
+            className="btn btn-sm btn-outline flex items-center space-x-2"
+          >
+            <PlayIcon className={`h-5 w-5 ${isPlaying ? "hidden" : ""}`} />
+            {isPlaying ? (
+              <svg // Pause Icon
+                xmlns="http://www.w3.org/2000/svg"
+                width="20"
+                height="20"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              >
+                <rect x="6" y="4" width="4" height="16" />
+                <rect x="14" y="4" width="4" height="16" />
+              </svg>
+            ) : null}
+            <span>{isPlaying ? "Pause Podcast" : "Play Podcast"}</span>
+          </button>
+        </div>
+      )}
+      {state && <ProblemVisualizer state={state} />}
+    </div>
+  );
 }

--- a/packages/problem-free/3sum/problem.ts
+++ b/packages/problem-free/3sum/problem.ts
@@ -30,4 +30,5 @@ export const problem: Problem<ThreeSumInput, ProblemState> = {
   codegen: {
     signature: "threeSteps(numbers: number[])",
   },
+  podcastUrl: "https://example.com/podcast/3sum.mp3", // Placeholder
 };


### PR DESCRIPTION
- Added `podcastUrl` field to the `Problem` type.
- Updated the `3sum` problem to include a placeholder podcast URL.
- Modified the frontend `ProblemView` component to display a play/pause button and control audio playback if a `podcastUrl` is available for the current problem.
- Added a `PlayIcon` component.